### PR TITLE
Two small fixes

### DIFF
--- a/tensor2tensor/data_generators/text_encoder.py
+++ b/tensor2tensor/data_generators/text_encoder.py
@@ -285,7 +285,7 @@ class SubwordTextEncoder(TextEncoder):
     subtokenizer.build_from_token_counts(token_counts, store_filename,
                                          present_count, num_iterations)
 
-    if min_val == max_val or subtokenizer.vocab_size == target_size:
+    if min_val >= max_val or subtokenizer.vocab_size == target_size:
       return subtokenizer
     elif subtokenizer.vocab_size > target_size:
       other_subtokenizer = cls.build_to_target_size(

--- a/tensor2tensor/data_generators/text_encoder.py
+++ b/tensor2tensor/data_generators/text_encoder.py
@@ -109,11 +109,11 @@ class TokenTextEncoder(TextEncoder):
 
   def __init__(self, vocab_filename, reverse=False, num_reserved_ids=2):
     """Initialize from a file, one token per line."""
-    self._reverse = reverse
-    if vocab_filename is None:
-      self._load_vocab_from_file(vocab_filename)
-
     super(TokenTextEncoder, self).__init__(num_reserved_ids=num_reserved_ids)
+
+    self._reverse = reverse
+    if vocab_filename is not None:
+      self._load_vocab_from_file(vocab_filename)
 
   def encode(self, sentence):
     """Converts a space-separated string of tokens to a list of ids."""


### PR DESCRIPTION
I encountered a few small bugs when trying this out, these commits appear to fix both. The errors I encountered were:

- the `TokenTextEncoder` constructor choked when I provided it with a vocab filename, both in that it didn't read the file (which caused `id_to_token` to not be initialized), and the super class constructor was called after some code that relied on the `num_reserved_ids` property to be set.
- the `build_to_target_size` method on `SubwordTextEncoder` could invert min / max during the binary search if the target vocab size was larger than the actual vocab size, which triggered an infinite loop with min 1 / max -1. I'm not sure if this is the best fix (should it short circuit return if the source vocab is already smaller than the target?).