### PR TITLE
setuptools: do not use gpu version of TensorFlow as hard requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'numpy',
         'sympy',
         'six',
-        'tensorflow-gpu>=1.2.0rc1',
+        'tensorflow>=1.2.0rc1',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Hi,

as discussed in #11 the gpu version of *TensorFlow* is not a hard requirement for `tensor2tensor`, as it can be run on cpu-only.

This PR removes the dependency for `tensorflow_gpu` in `setup.py`.