### PR TITLE
Ask for a pull request to avoid "index out ouf bound" when doing prediction

### DIFF
--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -269,6 +269,7 @@ class T2TModel(object):
       if last_position_only:
         cur_sample = samples[:, -1, :, :]
       else:
+        #Avoid the out of index Error
         if len(tf.shape(recent_output)) >= 2:
           cur_sample = samples[:, tf.shape(recent_output)[1], :, :]
         else:

--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -269,7 +269,10 @@ class T2TModel(object):
       if last_position_only:
         cur_sample = samples[:, -1, :, :]
       else:
-        cur_sample = samples[:, tf.shape(recent_output)[1], :, :]
+        if len(tf.shape(recent_output)) >= 2:
+          cur_sample = samples[:, tf.shape(recent_output)[1], :, :]
+        else:
+          cur_sample = samples[:, -1, :, :]
       cur_sample = tf.to_int64(tf.expand_dims(cur_sample, axis=1))
       samples = tf.concat([recent_output, cur_sample], axis=1)
       samples.set_shape([None, None, None, 1])


### PR DESCRIPTION
Hi, all
   I used to post a issue "https://github.com/tensorflow/tensor2tensor/issues/43" that will occur an "index out of bound" error in decoding.
  After I upgrade the tensor2tensor to 1.0.8, the problem still exists while happens in different place, but still when decoding.
  After some investigation, I found it seemed that it only happened when the target modality is ClassLabelModality. 
  I just made a quick fix to avoid this error index.  But I'm not a beam search expert and not aware of the potential problems.
  After employing this fix, my decoding seems good for now. 
  Would you please review this PR fix to see if it's ok. @lukaszkaiser 
  Thanks a lot!