### PR TITLE
Unicode in SubwordTextEncoder

### DIFF
--- a/tensor2tensor/data_generators/generator_utils.py
+++ b/tensor2tensor/data_generators/generator_utils.py
@@ -242,9 +242,12 @@ def get_or_generate_vocab(tmp_dir, vocab_filename, vocab_size):
 
       # For some datasets a second extraction is necessary.
       if ".gz" in lang_file:
-        tf.logging.info("Unpacking subdirectory %s" % filepath)
         new_filepath = os.path.join(tmp_dir, lang_file[:-3])
-        gunzip_file(filepath, new_filepath)
+        if os.path.exists(new_filepath):
+          tf.logging.info("Subdirectory %s already exists, skipping unpacking" % filepath)
+        else:
+          tf.logging.info("Unpacking subdirectory %s" % filepath)
+          gunzip_file(filepath, new_filepath)
         filepath = new_filepath
 
       # Use Tokenizer to count the word occurrences.

--- a/tensor2tensor/data_generators/generator_utils.py
+++ b/tensor2tensor/data_generators/generator_utils.py
@@ -258,7 +258,8 @@ def get_or_generate_vocab(tmp_dir, vocab_filename, vocab_size):
           _ = tokenizer.encode(line)
 
   vocab = SubwordTextEncoder.build_to_target_size(
-      vocab_size, tokenizer.token_counts, vocab_filepath, 1, 1e3)
+      vocab_size, tokenizer.token_counts, 1, 1e3)
+  vocab.store_to_file(vocab_filepath)
   return vocab
 
 

--- a/tensor2tensor/data_generators/generator_utils.py
+++ b/tensor2tensor/data_generators/generator_utils.py
@@ -22,7 +22,6 @@ import gzip
 import io
 import os
 import tarfile
-import urllib
 
 # Dependency imports
 

--- a/tensor2tensor/data_generators/snli.py
+++ b/tensor2tensor/data_generators/snli.py
@@ -136,14 +136,14 @@ def _get_or_generate_vocab(tmp_dir, vocab_filename, vocab_size):
   if tf.gfile.Exists(vocab_filepath):
     gs = text_encoder.SubwordTextEncoder(vocab_filepath)
     return gs
-  else:
-    example_file = os.path.join(tmp_dir, _EXAMPLES_FILE)
-    gs = text_encoder.SubwordTextEncoder()
-    token_counts = text_encoder.SubwordTextEncoder.get_token_counts(
-        example_file, corpus_max_lines=1000000)
-    gs = gs.build_to_target_size(
-        vocab_size, token_counts, vocab_filepath, min_val=1, max_val=1e3)
-    return gs
+  example_file = os.path.join(tmp_dir, _EXAMPLES_FILE)
+  gs = text_encoder.SubwordTextEncoder()
+  token_counts = text_encoder.SubwordTextEncoder.get_token_counts(
+      example_file, corpus_max_lines=1000000)
+  gs = gs.build_to_target_size(
+      vocab_size, token_counts, min_val=1, max_val=1e3)
+  gs.store_to_file(vocab_filepath)
+  return gs
 
 
 def snli_token_generator(tmp_dir, train, vocab_size):

--- a/tensor2tensor/data_generators/text_encoder_build_subword.py
+++ b/tensor2tensor/data_generators/text_encoder_build_subword.py
@@ -59,8 +59,9 @@ def main(unused_argv):
     raise ValueError('Must provide --corpus_filepattern')
   token_counts = text_encoder.SubwordTextEncoder.get_token_counts(
       FLAGS.corpus_filepattern, FLAGS.corpus_max_lines)
-  gs.build_from_token_counts(token_counts, FLAGS.output_fn, FLAGS.min_count,
+  gs.build_from_token_counts(token_counts, FLAGS.min_count,
                              FLAGS.num_iterations)
+  gs.store_to_file(FLAGS.output_fn)
 
 
 if __name__ == '__main__':

--- a/tensor2tensor/data_generators/text_encoder_build_subword.py
+++ b/tensor2tensor/data_generators/text_encoder_build_subword.py
@@ -59,7 +59,9 @@ def main(unused_argv):
     raise ValueError('Must provide --corpus_filepattern')
   token_counts = text_encoder.SubwordTextEncoder.get_token_counts(
       FLAGS.corpus_filepattern, FLAGS.corpus_max_lines)
-  gs.build_from_token_counts(token_counts, FLAGS.min_count,
+  alphabet_set = SubwordTextEncoder.alphabet(token_counts)
+  gs.build_from_token_counts(token_counts, alphabet_set,
+                             FLAGS.min_count,
                              FLAGS.num_iterations)
   gs.store_to_file(FLAGS.output_fn)
 

--- a/tensor2tensor/data_generators/tokenizer.py
+++ b/tensor2tensor/data_generators/tokenizer.py
@@ -14,24 +14,26 @@
 
 """A simple invertible tokenizer.
 
-Converts from a raw string to a list of tokens (strings).
+Converts from a raw string to a list of tokens (represented as
+Unicode strings).
 
 This tokenizer has the following desirable properties:
  - It is invertible.
  - Punctuation is broken away from adjacent letters.
  - A single space between words does not produce an extra token.
+ - The full Unicode punctuation and separator set is recognized.
 
 The tokenization algorithm is as follows:
 
-0.  We classify the 256 characters into "word characters" and
+0.  We classify the input characters into "word characters" and
     "separator characters".  Separator characters are defined as the union of
-    string.punctuation and string.whitespace.  All other characters are
+    Unicode punctuation and separators/white space.  All other characters are
     "word characters".
 
 1.  Split the text into a list of tokens, splitting at every boundary of a
     "word character" and a "separator character".  This produces a list which
-    alternates between "word tokens" (strings of word characters) and
-    "separator tokens" (strings of of separator characters).
+    alternates between "word tokens" (strings of word codepoints) and
+    "separator tokens" (strings of of separator/punctuation codepoints).
 
 2.  Remove every token consisting of a single space, unless it is
     the very first or very last token in the list.  These tokens are now
@@ -53,25 +55,29 @@ import re
 
 # Dependency imports
 
-from six import PY2
+from six import PY2, unichr  # pylint: disable=redefined-builtin
 from six.moves import xrange  # pylint: disable=redefined-builtin
-
 
 # Regular expression that matches Unicode whitespace characters
 # (including ASCII whitespace) as defined in the Python run-time library
 _RE_WHITESPACE = re.compile(r"^\s$", re.UNICODE)
+
+# Set of Unicode whitespace code points
+UNICODE_WHITESPACE = set(unichr(i) for i in xrange(sys.maxunicode)
+                          if _RE_WHITESPACE.match(unichr(i)))
+# Set of Unicode punctuation code points
+UNICODE_PUNCTUATION = set(unichr(i) for i in xrange(sys.maxunicode)
+                          if unicodedata.category(unichr(i)).startswith('P'))
+# Conversion between Unicode and UTF-8, if required (on Python2)
+_decode_string = (lambda s: s.decode('utf-8')) if PY2 else (lambda s: s)
+_encode_string = (lambda s: s.encode('utf-8')) if PY2 else (lambda s: s)
 
 
 class Tokenizer(object):
   """Vocab for breaking words into Unicode wordpieces.
   """
 
-  _UNICODE_PUNCTUATION = set(unichr(i) for i in xrange(sys.maxunicode)
-                             if unicodedata.category(unichr(i)).startswith('P'))
-  _UNICODE_WHITESPACE = set(unichr(i) for i in xrange(sys.maxunicode)
-                            if _RE_WHITESPACE.match(unichr(i)))
-  #_SEPARATOR_CHAR_SET = set(string.punctuation + string.whitespace)
-  _SEPARATOR_CHAR_SET = _UNICODE_WHITESPACE | _UNICODE_PUNCTUATION
+  _SEPARATOR_CHAR_SET = UNICODE_WHITESPACE | UNICODE_PUNCTUATION
 
   def __init__(self):
     self.token_counts = defaultdict(int)
@@ -82,23 +88,22 @@ class Tokenizer(object):
     Args:
       raw_text: a (Python2 or Python3 native) string
     Returns:
-      a list of Unicode strings
+      a list of tokens as Unicode strings
     """
     if not raw_text:
       return []
     ret = []
     token_start = 0
-    if PY2:
-      raw_text = raw_text.decode('utf-8') # Convert to Unicode
-    is_sep = [self._is_separator_char(c) for c in raw_text]
-    for pos in xrange(1, len(raw_text)):
-      if (is_sep[pos] != is_sep[pos-1]):
-        token = raw_text[token_start:pos]
+    unicode_text = _decode_string(raw_text)
+    is_sep = [c in self._SEPARATOR_CHAR_SET for c in unicode_text]
+    for pos in xrange(1, len(unicode_text)):
+      if is_sep[pos] != is_sep[pos - 1]:
+        token = unicode_text[token_start:pos]
         if token != u" " or token_start == 0:
           ret.append(token)
           self.token_counts[token] += 1
         token_start = pos
-    final_token = raw_text[token_start:]
+    final_token = unicode_text[token_start:]
     ret.append(final_token)
     self.token_counts[final_token] += 1
     return ret
@@ -112,15 +117,10 @@ class Tokenizer(object):
       a (Python2 or Python3 native) string
     """
     ret = u""
-    is_word = [self._is_word_char(t[0]) for t in tokens]
+    is_word = [t[0] not in self._SEPARATOR_CHAR_SET for t in tokens]
     for i, token in enumerate(tokens):
       if i > 0 and is_word[i - 1] and is_word[i]:
         ret += u" "
       ret += token
-    return ret.encode('utf-8') if PY2 else ret
+    return _encode_string(ret)
 
-  def _is_separator_char(self, c):
-    return c in self._SEPARATOR_CHAR_SET
-
-  def _is_word_char(self, c):
-    return c not in self._SEPARATOR_CHAR_SET

--- a/tensor2tensor/data_generators/tokenizer.py
+++ b/tensor2tensor/data_generators/tokenizer.py
@@ -67,10 +67,10 @@ UNICODE_WHITESPACE = set(unichr(i) for i in xrange(sys.maxunicode)
                           if _RE_WHITESPACE.match(unichr(i)))
 # Set of Unicode punctuation code points
 UNICODE_PUNCTUATION = set(unichr(i) for i in xrange(sys.maxunicode)
-                          if unicodedata.category(unichr(i)).startswith('P'))
+                          if unicodedata.category(unichr(i)).startswith("P"))
 # Conversion between Unicode and UTF-8, if required (on Python2)
-_decode_string = (lambda s: s.decode('utf-8')) if PY2 else (lambda s: s)
-_encode_string = (lambda s: s.encode('utf-8')) if PY2 else (lambda s: s)
+_decode_string = (lambda s: s.decode("utf-8")) if PY2 else (lambda s: s)
+_encode_string = (lambda s: s.encode("utf-8")) if PY2 else (lambda s: s)
 
 
 class Tokenizer(object):
@@ -95,6 +95,7 @@ class Tokenizer(object):
     ret = []
     token_start = 0
     unicode_text = _decode_string(raw_text)
+    # Classify each character in the input string
     is_sep = [c in self._SEPARATOR_CHAR_SET for c in unicode_text]
     for pos in xrange(1, len(unicode_text)):
       if is_sep[pos] != is_sep[pos - 1]:


### PR DESCRIPTION
This PR updates the Tokenizer and the SubwordTextEncoder to be Unicode-based instead of UTF-8 based.

This means that the full Unicode set of punctuation and separator characters is recognized when tokenizing the text, and that wordpieces are always formed at bone fide Unicode character boundaries. The former improvement helps to clean up the vocabulary and make it more efficient, since Unicode punctuation such as proper double quotes and em dashes is no longer seen as parts of words, while the latter avoids potential errors when wordpieces could start or end within UTF-8 multi-byte sequences denoting a single character.

The drawback is that it is not feasible to include the entire set of Unicode code points in the vocabulary (in contrast with including all code points 0..255 for UTF-8). This is mitigated by careful coding to make sure that all Unicode input appearing in the tokenizer training set is represented in the vocabulary, but if Unicode code points later appear during inference that were not seen during training, they are mapped to Unicode REPLACEMENT_CHARACTER (uFFFD). This should not impact performance in any meaningful way.

I believe this PR is especially beneficial for processing of text in non-ISO-Latin-1 languages that rely heavily on Unicode, such as Chinese, Hindi, Turkish, etc.

Secondarily, the PR contains a couple of performance enhancements, such as only writing a vocabulary file at the end of the binary search for an optimal vocabulary, not for every intermediate result (which could in fact lead to a nonoptimal vocabulary file being the last written one).

This PR has been tested and works (AFAIK :-) ) under both Python2 and Python3.