### PR TITLE
I'm afraid I need to ask for pull request again for the "Out of index" Error when doing Class_Label_Modality

### DIFF
--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -196,7 +196,10 @@ class T2TModel(object):
       if last_position_only:
         return tf.squeeze(logits, axis=[1, 2, 3])
       current_output_position = tf.shape(ids)[1] - 1  # -1 due to the pad above.
-      logits = logits[:, current_output_position, :, :]
+      if current_output_position.shape.ndims >= 1:
+        logits = logits[:, current_output_position, :, :]
+      else:
+        logits = logits[:, -1 , :, :]
       return tf.squeeze(logits, axis=[1, 2])
 
     batch_size = tf.shape(features["inputs"])[0]
@@ -270,7 +273,7 @@ class T2TModel(object):
         cur_sample = samples[:, -1, :, :]
       else:
         #Avoid the out of index Error
-        if len(tf.shape(recent_output)) >= 2:
+        if tf.shape(recent_output).shape.ndims >= 2:
           cur_sample = samples[:, tf.shape(recent_output)[1], :, :]
         else:
           cur_sample = samples[:, -1, :, :]


### PR DESCRIPTION
First of all, I apologize for the previous error that I misused the len operator.
Then I figure out if the beam is set to the value that's greater than 1 will still cause the Out of index error.

For Class_Label_Modality search , beam is set to 1 to enable greedy_infere seems to get better results.
@lukaszkaiser 
1. for beam search use the shape.ndims to avoid out of index error
2. for greedy search, still use the shape.ndims to avoid the out of index error. Before that I misuse the slice operation:-(