### PR TITLE
Bump to v1.0.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='tensor2tensor',
-    version='1.0.9',
+    version='1.0.10',
     description='Tensor2Tensor',
     author='Google Inc.',
     author_email='no-reply@google.com',


### PR DESCRIPTION
Hi,

with release *1.0.10* (see [Release page](https://github.com/tensorflow/tensor2tensor/releases)) the version number in `setup.py` was not updated.

So e.g. `pip` can't find the latest version:

```bash
pip install --upgrade "tensor2tensor==1.0.10"
Collecting tensor2tensor==1.0.10
  Could not find a version that satisfies the requirement tensor2tensor==1.0.10 (from versions: 1.0, 1.0.1.dev1, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 1.0.7, 1.0.8, 1.0.9)
No matching distribution found for tensor2tensor==1.0.10
```

This PR fixes it :)