### PR TITLE
Bump to v1.0.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='tensor2tensor',
-    version='1.0.10',
+    version='1.0.11',
     description='Tensor2Tensor',
     author='Google Inc.',
     author_email='no-reply@google.com',


### PR DESCRIPTION
Bumps version information in `setup.py` to the latest *1.0.11* release (so that `pip` can find it).