### PR TITLE
Add new set network layer type and example model

### DIFF
--- a/tensor2tensor/models/common_layers_test.py
+++ b/tensor2tensor/models/common_layers_test.py
@@ -50,7 +50,7 @@ class CommonLayersTest(tf.test.TestCase):
     self.assertAllClose(res, [0.0, 0.0, 0.5, 1.0, 1.0])
 
   def testFlatten4D3D(self):
-    x = np.random.random_integers(1, high=8, size=(3, 5, 2))
+    x = np.random.randint(1, 9, size=(3, 5, 2))
     with self.test_session() as session:
       y = common_layers.flatten4d3d(common_layers.embedding(x, 10, 7))
       session.run(tf.global_variables_initializer())
@@ -58,7 +58,7 @@ class CommonLayersTest(tf.test.TestCase):
     self.assertEqual(res.shape, (3, 5 * 2, 7))
 
   def testEmbedding(self):
-    x = np.random.random_integers(1, high=8, size=(3, 5))
+    x = np.random.randint(1, 9, size=(3, 5))
     with self.test_session() as session:
       y = common_layers.embedding(x, 10, 16)
       session.run(tf.global_variables_initializer())
@@ -81,6 +81,14 @@ class CommonLayersTest(tf.test.TestCase):
       session.run(tf.global_variables_initializer())
       res = session.run(y)
     self.assertEqual(res.shape, (5, 5, 1, 13))
+    
+  def testConv1d(self):
+    x = np.random.rand(5, 7, 11)
+    with self.test_session() as session:
+      y = common_layers.conv1d(tf.constant(x, dtype=tf.float32), 13, 1)
+      session.run(tf.global_variables_initializer())
+      res = session.run(y)
+    self.assertEqual(res.shape, (5, 7, 13))
 
   def testSeparableConv(self):
     x = np.random.rand(5, 7, 1, 11)
@@ -293,6 +301,66 @@ class CommonLayersTest(tf.test.TestCase):
       session.run(tf.global_variables_initializer())
       actual = session.run(a)
     self.assertEqual(actual.shape, (5, 32, 1, 16))
+    
+  def testGlobalPool1d(self):
+    shape = (5, 4)
+    x1 = np.random.rand(5,4,11)
+    #mask = np.random.randint(2, size=shape)
+    no_mask = np.ones((5,4))
+    full_mask = np.zeros((5,4))
+    
+    with self.test_session() as session:
+      x1_ = tf.Variable(x1, dtype=tf.float32)
+      no_mask_ = tf.Variable(no_mask, dtype=tf.float32)
+      full_mask_ = tf.Variable(full_mask, dtype=tf.float32)
+      
+      none_mask_max = common_layers.global_pool_1d(x1_)
+      no_mask_max = common_layers.global_pool_1d(x1_, mask=no_mask_)
+      result1 = tf.reduce_sum(none_mask_max - no_mask_max)
+      
+      full_mask_max = common_layers.global_pool_1d(x1_, mask=full_mask_)
+      result2 = tf.reduce_sum(full_mask_max)
+      
+      none_mask_avr = common_layers.global_pool_1d(x1_, 'AVR')
+      no_mask_avr = common_layers.global_pool_1d(x1_, 'AVR', no_mask_)
+      result3 = tf.reduce_sum(none_mask_avr - no_mask_avr)
+      
+      full_mask_avr = common_layers.global_pool_1d(x1_, 'AVR', full_mask_)
+      result4 = tf.reduce_sum(full_mask_avr)
+      
+      session.run(tf.global_variables_initializer())
+      actual = session.run([result1, result2, result3, result4])
+      # N.B: Last result will give a NaN.
+    self.assertAllEqual(actual[:3], [0.0, 0.0, 0.0])
+
+
+  def testLinearSetLayer(self):
+    x1 = np.random.rand(5,4,11)
+    cont = np.random.rand(5,13)
+    with self.test_session() as session:
+      x1_ = tf.Variable(x1, dtype=tf.float32)
+      cont_ = tf.Variable(cont, dtype=tf.float32)
+      
+      simple_ff = common_layers.linear_set_layer(32, x1_)
+      cont_ff = common_layers.linear_set_layer(32, x1_, context=cont_)
+      
+      session.run(tf.global_variables_initializer())
+      actual = session.run([simple_ff, cont_ff])
+    self.assertEqual(actual[0].shape, (5,4,32))
+    self.assertEqual(actual[1].shape, (5,4,32))
+    
+  def testRavanbakhshSetLayer(self):
+    x1 = np.random.rand(5,4,11)
+    cont = np.random.rand(5,13)
+    with self.test_session() as session:
+      x1_ = tf.Variable(x1, dtype=tf.float32)
+      cont_ = tf.Variable(cont, dtype=tf.float32)
+      
+      layer = common_layers.ravanbakhsh_set_layer(32, x1_)
+      
+      session.run(tf.global_variables_initializer())
+      actual = session.run(layer)
+    self.assertEqual(actual.shape, (5,4,32))
 
 
 if __name__ == "__main__":

--- a/tensor2tensor/models/transformer_alternative_.py
+++ b/tensor2tensor/models/transformer_alternative_.py
@@ -1,0 +1,172 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" 
+    Alternative transformer network using different layer types to demonstrate
+    alternatives to self attention.
+
+    Code is mostly copied from original Transformer source (if that wasn't
+    already obvious).
+
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import copy
+
+# Dependency imports
+
+from six.moves import xrange  # pylint: disable=redefined-builtin
+
+from tensor2tensor.models import common_attention
+from tensor2tensor.models import common_hparams
+from tensor2tensor.models import common_layers
+from tensor2tensor.models import transformer
+from tensor2tensor.utils import registry
+from tensor2tensor.utils import t2t_model
+
+import tensorflow as tf
+
+
+@registry.register_model
+class TransformerAlt(t2t_model.T2TModel):
+
+  def model_fn_body(self, features):
+    #
+  
+    # Remove dropout if not training
+    hparams = copy.copy(self._hparams)
+    targets = features["targets"]
+    inputs = features.get("inputs")
+    target_space = features.get("target_space_id")
+
+    inputs = common_layers.flatten4d3d(inputs)
+    targets = common_layers.flatten4d3d(targets)
+
+    (encoder_input, encoder_attention_bias, _) = (transformer.\
+        transformer_prepare_encoder(inputs, target_space, hparams) )
+    (decoder_input, decoder_self_attention_bias) = transformer.\
+        transformer_prepare_decoder(targets, hparams)
+
+    def residual_fn(x, y):
+      return common_layers.layer_norm(x + tf.nn.dropout(
+          y, 1.0 - hparams.residual_dropout))
+
+    encoder_input = tf.nn.dropout(encoder_input, 1.0 - hparams.residual_dropout)
+    decoder_input = tf.nn.dropout(decoder_input, 1.0 - hparams.residual_dropout)
+    encoder_output = alt_transformer_encoder(
+        encoder_input, residual_fn, encoder_attention_bias, hparams)
+
+    decoder_output = alt_transformer_decoder(
+        decoder_input, encoder_output, residual_fn, decoder_self_attention_bias,
+        encoder_attention_bias, hparams)
+        
+    decoder_output = tf.expand_dims(decoder_output, 2)
+
+    return decoder_output
+    
+    
+def alt_transformer_encoder(encoder_input,
+                            residual_fn,
+                            encoder_attention_bias,
+                            hparams,
+                            name="encoder"):
+  """
+  A stack of transformer layers.
+
+  Args:
+    encoder_input: a Tensor
+    residual_fn: a function from (layer_input, layer_output) -> combined_output
+
+    hparams: hyperparameters for model
+    name: a string
+
+  Returns:
+    y: a Tensors
+  """
+  x = encoder_input
+  
+  # Summaries don't work in multi-problem setting yet.
+  summaries = "problems" not in hparams.values() or len(hparams.problems) == 1
+  
+  with tf.variable_scope(name):
+    for layer in xrange(hparams.num_hidden_layers):
+      with tf.variable_scope("layer_%d" % layer):
+        x = residual_fn(
+            x,
+            ravanbakhsh_set_layer(hparams.hidden_size, x, mask=encoder_attention_bias)
+        )
+        
+  return x
+
+
+def alt_transformer_decoder(decoder_input,
+                            encoder_output,
+                            residual_fn,
+                            decoder_self_attention_bias,
+                            encoder_decoder_attention_bias,
+                            hparams,
+                            name="decoder"):
+  """
+  A stack of transformer layers.
+
+  Args:
+    decoder_input: a Tensor
+    encoder_output: a Tensor
+    residual_fn: a function from (layer_input, layer_output) -> combined_output
+    encoder_decoder_attention_bias: bias Tensor for encoder-decoder attention
+      (see common_attention.attention_bias())
+    hparams: hyperparameters for model
+    name: a string
+
+  Returns:
+    y: a Tensors
+  """
+  x = decoder_input
+  
+  # Summaries don't work in multi-problem setting yet.
+  summaries = "problems" not in hparams.values() or len(hparams.problems) == 1
+  with tf.variable_scope(name):
+    for layer in xrange(hparams.num_hidden_layers):
+      with tf.variable_scope("layer_%d" % layer):
+        
+        x = residual_fn(
+            x,
+            ravanbakhsh_set_layer(hparams.hidden_size,
+                common_attention.multihead_attention(
+                    x,
+                    encoder_output,
+                    encoder_decoder_attention_bias,
+                    hparams.attention_key_channels or hparams.hidden_size,
+                    hparams.attention_value_channels or hparams.hidden_size,
+                    hparams.hidden_size,
+                    hparams.num_heads,
+                    hparams.attention_dropout,
+                    summaries=summaries,
+                    name="encdec_attention"),
+            mask=decoder_self_attention_bias)
+        )
+        
+  return x
+
+
+@registry.register_hparams
+def transformer_alt():
+  """Set of hyperparameters."""
+  hparams = transformer.transformer_base()
+  hparams.add_hparam("layers_per_layer", 4)
+  return hparams
+

--- a/tensor2tensor/models/transformer_test.py
+++ b/tensor2tensor/models/transformer_test.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from tensor2tensor.data_generators import problem_hparams
 from tensor2tensor.models import transformer
+from tensor2tensor.models import transformer_alternative
 
 import tensorflow as tf
 


### PR DESCRIPTION
Added the following layers (and tests):

*`global_pool_1d`: Not much to this, just a simple max/mean reduce across all vectors in a sequence. Useful for getting a single vector representation of a sequence/set. This can also be thought of as a kind of global attention.
* `linear_set_layer`: Simple 1d convolution across all elements in a sequence (similar layers are already used in repo), but also includes the ability to parameterise the transformation via with a (learned) sequence 'context' vector. Currently this is done by simply concatenating the inputs with the context.
*`ravanbakhsh_set_layer`: Layer type used in https://arxiv.org/abs/1611.04500.

These layers are permutation invariant and hence are suitable for applications where inputs are given as sets, but they may also be useful for sequence tasks as well.

Also added an example model `transformer_alt` which replaces the self attention layers in `transformer` with two different kinds of modules composed of the layers described above. I have no idea how well it performs (although similar previous architectures I tested seemed to do only slightly worse than the full transformer).

N.B: I have not extensively tested these layers in t2t, so it's entirely possible that they're not perfectly functional (particularly wrt to masking).

Also changed two lines in tests to stop numpy warnings.