### PR TITLE
Add automated flake8 testing on all pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+    - 2.7.13
+    - 3.6.2
+install:
+    - pip install flake8
+script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+notifications:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
The owner of the tensorflow GitHub ID would need to go to https://travis-ci.org/profile and flip on the repository switch.