### PR TITLE
Simplify adding new translation language pairs

### DIFF
--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -69,6 +69,10 @@ class SpaceID(object):
   ICE_PARSE_TOK = 19
   # Macedonian tokens
   MK_TOK = 20
+  # Czech tokens
+  CS_TOK = 21
+  # Czech characters
+  CS_CHR = 22
 
 
 class Problem(object):

--- a/tensor2tensor/data_generators/problem_hparams.py
+++ b/tensor2tensor/data_generators/problem_hparams.py
@@ -180,6 +180,9 @@ def default_problem_hparams():
       #   17: Icelandic characters
       #   18: Icelandic tokens
       #   19: Icelandic parse tokens
+      #   20: Macedonian tokens
+      #   21: Czech tokens
+      #   22: Czech characters
       # Add more above if needed.
       input_space_id=0,
       target_space_id=0,


### PR DESCRIPTION
* simplify wmt.py:
`train_generator` is now a method (not a property returning a function)
and WMTProblem subclasses implement it directly (not via one-purpose functions)
* add WMT English-Czech translation problems
* introduce `vocab_name` property, so e.g. `tokens.vocab-en-cs.32768` is used instead of `tokens.vocab.32768` if only English+Czech datasets were used