### PR TITLE
fix positional embedding

### DIFF
--- a/tensor2tensor/models/common_attention.py
+++ b/tensor2tensor/models/common_attention.py
@@ -65,6 +65,9 @@ def add_timing_signal_1d(x, min_timescale=1.0, max_timescale=1.0e4):
       tf.to_float(tf.range(num_timescales)) * -log_timescale_increment)
   scaled_time = tf.expand_dims(position, 1) * tf.expand_dims(inv_timescales, 0)
   signal = tf.concat([tf.sin(scaled_time), tf.cos(scaled_time)], axis=1)
+  signal = tf.reshape(signal, [length, 2, num_timescales])
+  signal = tf.transpose(signal, perm=[0, 2, 1])
+  signal = tf.reshape(signal, [length, channels])
   signal = tf.pad(signal, [[0, 0], [0, tf.mod(channels, 2)]])
   signal = tf.reshape(signal, [1, length, channels])
   return x + signal


### PR DESCRIPTION
This PR is to fix the positional embeddings in the [codes](https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/models/common_attention.py#L29)

As mentioned in the paper, the positional embedding should be 
![image](https://user-images.githubusercontent.com/9649941/28421359-8a8d38a8-6d97-11e7-8a18-a78f9e5a2efb.png)

while in the code, it's calculated as 
![image](https://user-images.githubusercontent.com/9649941/28421388-a38a8b9e-6d97-11e7-8faa-e57d1a3cda65.png)

Please check the differences.