### PR TITLE
Remove input sentence from decoded file

### DIFF
--- a/tensor2tensor/utils/get_ende_bleu.sh
+++ b/tensor2tensor/utils/get_ende_bleu.sh
@@ -5,10 +5,8 @@ tok_gold_targets=newstest2013.tok.de
 
 decodes_file=$1
 
-cut -d'	' -f1 $decodes_file > $decodes_file.target
-
 # Tokenize.
-perl $mosesdecoder/scripts/tokenizer/tokenizer.perl -l de < $decodes_file.target > $decodes_file.tok
+perl $mosesdecoder/scripts/tokenizer/tokenizer.perl -l de < $decodes_file > $decodes_file.tok
 
 # Put compounds in ATAT format (comparable to papers like GNMT, ConvS2S).
 # See https://nlp.stanford.edu/projects/nmt/ :

--- a/tensor2tensor/utils/trainer_utils.py
+++ b/tensor2tensor/utils/trainer_utils.py
@@ -703,8 +703,7 @@ def decode_from_file(estimator, filename):
   tf.logging.info("Writing decodes into %s" % decode_filename)
   outfile = tf.gfile.Open(decode_filename, "w")
   for index in range(len(sorted_inputs)):
-    outfile.write("%s\t%s\n" % (decodes[sorted_keys[index]],
-                                sorted_inputs[sorted_keys[index]]))
+    outfile.write("%s\n" % (decodes[sorted_keys[index]]))
 
 
 def decode_interactively(estimator):


### PR DESCRIPTION
Hi,

this PR removes the input sentence from the decoded file for `wmt_*` problems. 

It makes it harder for BLEU-score calculation when the input sentence is also shown. This was discussed in #112.

The example script for calculation the BLEU-score for a EN-DE system (`get_ende_bleu.sh`) is also updated with this PR.