### PR TITLE
Simplify adding new translation language pairs

### DIFF
--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -69,6 +69,10 @@ class SpaceID(object):
   ICE_PARSE_TOK = 19
   # Macedonian tokens
   MK_TOK = 20
+  # Czech tokens
+  CS_TOK = 21
+  # Czech characters
+  CS_CHR = 22
 
 
 class Problem(object):

--- a/tensor2tensor/data_generators/problem_hparams.py
+++ b/tensor2tensor/data_generators/problem_hparams.py
@@ -180,6 +180,9 @@ def default_problem_hparams():
       #   17: Icelandic characters
       #   18: Icelandic tokens
       #   19: Icelandic parse tokens
+      #   20: Macedonian tokens
+      #   21: Czech tokens
+      #   22: Czech characters
       # Add more above if needed.
       input_space_id=0,
       target_space_id=0,

--- a/tensor2tensor/data_generators/wmt.py
+++ b/tensor2tensor/data_generators/wmt.py
@@ -42,23 +42,6 @@ FLAGS = tf.flags.FLAGS
 EOS = text_encoder.EOS_ID
 
 
-def _default_token_feature_encoders(data_dir, target_vocab_size):
-  vocab_filename = os.path.join(data_dir,
-                                "vocab.endefr.%d" % target_vocab_size)
-  subtokenizer = text_encoder.SubwordTextEncoder(vocab_filename)
-  return {
-      "inputs": subtokenizer,
-      "targets": subtokenizer,
-  }
-
-
-def _default_character_feature_encoders():
-  return {
-      "inputs": text_encoder.ByteTextEncoder(),
-      "targets": text_encoder.ByteTextEncoder(),
-  }
-
-
 class WMTProblem(problem.Problem):
   """Base class for WMT problems."""
 
@@ -70,14 +53,13 @@ class WMTProblem(problem.Problem):
   def targeted_vocab_size(self):
     raise NotImplementedError()  # Not needed if self.is_character_level.
 
-  @property
-  def train_generator(self):
-    """Generator; takes data_dir, tmp_dir, is_training, targeted_vocab_size."""
+  def train_generator(self, data_dir, tmp_dir, is_training):
+    """Generator of the training data."""
     raise NotImplementedError()
 
-  @property
-  def dev_generator(self):
-    return self.train_generator
+  def dev_generator(self, data_dir, tmp_dir, is_training):
+    """Generator of the development data."""
+    return self.train_generator(data_dir, tmp_dir, is_training)
 
   @property
   def input_space_id(self):
@@ -91,28 +73,35 @@ class WMTProblem(problem.Problem):
   def num_shards(self):
     return 100
 
+  @property
+  def vocab_name(self):
+    return "vocab.endefr"
+
+  @property
+  def vocab_file(self):
+    return "%s.%d" % (self.vocab_name, self.targeted_vocab_size)
+
   def generate_data(self, data_dir, tmp_dir, num_shards=None):
     if num_shards is None:
       num_shards = self.num_shards
-    if self.is_character_level:
-      generator_utils.generate_dataset_and_shuffle(
-          self.train_generator(tmp_dir, True),
-          self.training_filepaths(data_dir, num_shards, shuffled=False),
-          self.dev_generator(tmp_dir, False),
-          self.dev_filepaths(data_dir, 1, shuffled=False))
-    else:
-      generator_utils.generate_dataset_and_shuffle(
-          self.train_generator(data_dir, tmp_dir, True,
-                               self.targeted_vocab_size),
-          self.training_filepaths(data_dir, num_shards, shuffled=False),
-          self.dev_generator(data_dir, tmp_dir, False,
-                             self.targeted_vocab_size),
-          self.dev_filepaths(data_dir, 1, shuffled=False))
+    generator_utils.generate_dataset_and_shuffle(
+      self.train_generator(data_dir, tmp_dir, True),
+      self.training_filepaths(data_dir, num_shards, shuffled=False),
+      self.dev_generator(data_dir, tmp_dir, False),
+      self.dev_filepaths(data_dir, 1, shuffled=False))
 
   def feature_encoders(self, data_dir):
     if self.is_character_level:
-      return _default_character_feature_encoders()
-    return _default_token_feature_encoders(data_dir, self.targeted_vocab_size)
+      return {
+        "inputs": text_encoder.ByteTextEncoder(),
+        "targets": text_encoder.ByteTextEncoder(),
+      }
+    vocab_filename = os.path.join(data_dir, self.vocab_file)
+    subtokenizer = text_encoder.SubwordTextEncoder(vocab_filename)
+    return {
+      "inputs": subtokenizer,
+      "targets": subtokenizer,
+    }
 
   def hparams(self, defaults, unused_model_hparams):
     p = defaults
@@ -174,8 +163,8 @@ def tabbed_generator(source_path, source_vocab, target_vocab, eos=None):
 
   Args:
     source_path: path to the file with source and target sentences.
-    source_vocab: a SunwordTextEncoder to encode the source string.
-    target_vocab: a SunwordTextEncoder to encode the target string.
+    source_vocab: a SubwordTextEncoder to encode the source string.
+    target_vocab: a SubwordTextEncoder to encode the target string.
     eos: integer to append at the end of each sequence (default: None).
 
   Yields:
@@ -336,6 +325,29 @@ _MKEN_TEST_DATASETS = [[
     ("dev.mk", "dev.en")
 ]]
 
+# English-Czech datasets
+_ENCS_TRAIN_DATASETS = [
+    [
+        "http://data.statmt.org/wmt16/translation-task/training-parallel-nc-v11.tgz",  # pylint: disable=line-too-long
+        ("training-parallel-nc-v11/news-commentary-v11.cs-en.en",
+         "training-parallel-nc-v11/news-commentary-v11.cs-en.cs")
+    ],
+    [
+        "http://www.statmt.org/wmt13/training-parallel-commoncrawl.tgz",
+        ("commoncrawl.cs-en.en", "commoncrawl.cs-en.cs")
+    ],
+    [
+        "http://www.statmt.org/wmt13/training-parallel-europarl-v7.tgz",
+        ("training/europarl-v7.cs-en.en", "training/europarl-v7.cs-en.cs")
+    ],
+]
+_ENCS_TEST_DATASETS = [
+    [
+        "http://data.statmt.org/wmt16/translation-task/dev.tgz",
+        ("dev/newstest2013.en", "dev/newstest2013.cs")
+    ],
+]
+
 
 # Generators.
 
@@ -407,16 +419,6 @@ def _compile_data(tmp_dir, datasets, filename):
   return filename
 
 
-def ende_wordpiece_token_generator(data_dir, tmp_dir, train, vocab_size):
-  symbolizer_vocab = generator_utils.get_or_generate_vocab(
-      data_dir, tmp_dir, "vocab.endefr.%d" % vocab_size, vocab_size)
-  datasets = _ENDE_TRAIN_DATASETS if train else _ENDE_TEST_DATASETS
-  tag = "train" if train else "dev"
-  data_path = _compile_data(tmp_dir, datasets, "wmt_ende_tok_%s" % tag)
-  return token_generator(data_path + ".lang1", data_path + ".lang2",
-                         symbolizer_vocab, EOS)
-
-
 @registry.register_problem("wmt_ende_tokens_8k")
 class WMTEnDeTokens8k(WMTProblem):
   """Problem spec for WMT En-De translation."""
@@ -425,9 +427,13 @@ class WMTEnDeTokens8k(WMTProblem):
   def targeted_vocab_size(self):
     return 2**13  # 8192
 
-  @property
-  def train_generator(self):
-    return ende_wordpiece_token_generator
+  def train_generator(self, data_dir, tmp_dir, train):
+    symbolizer_vocab = generator_utils.get_or_generate_vocab(
+        data_dir, tmp_dir, self.vocab_file, self.targeted_vocab_size)
+    datasets = _ENDE_TRAIN_DATASETS if train else _ENDE_TEST_DATASETS
+    tag = "train" if train else "dev"
+    data_path = _compile_data(tmp_dir, datasets, "wmt_ende_tok_%s" % tag)
+    return token_generator(data_path + ".lang1", data_path + ".lang2", symbolizer_vocab, EOS)
 
   @property
   def input_space_id(self):
@@ -446,15 +452,6 @@ class WMTEnDeTokens32k(WMTEnDeTokens8k):
     return 2**15  # 32768
 
 
-def ende_character_generator(tmp_dir, train):
-  character_vocab = text_encoder.ByteTextEncoder()
-  datasets = _ENDE_TRAIN_DATASETS if train else _ENDE_TEST_DATASETS
-  tag = "train" if train else "dev"
-  data_path = _compile_data(tmp_dir, datasets, "wmt_ende_chr_%s" % tag)
-  return character_generator(data_path + ".lang1", data_path + ".lang2",
-                             character_vocab, EOS)
-
-
 @registry.register_problem("wmt_ende_characters")
 class WMTEnDeCharacters(WMTProblem):
   """Problem spec for WMT En-De translation."""
@@ -463,9 +460,13 @@ class WMTEnDeCharacters(WMTProblem):
   def is_character_level(self):
     return True
 
-  @property
-  def train_generator(self):
-    return ende_character_generator
+  def train_generator(self, tmp_dir, train):
+    character_vocab = text_encoder.ByteTextEncoder()
+    datasets = _ENDE_TRAIN_DATASETS if train else _ENDE_TEST_DATASETS
+    tag = "train" if train else "dev"
+    data_path = _compile_data(tmp_dir, datasets, "wmt_ende_chr_%s" % tag)
+    return character_generator(data_path + ".lang1", data_path + ".lang2",
+                                character_vocab, EOS)
 
   @property
   def input_space_id(self):
@@ -476,29 +477,6 @@ class WMTEnDeCharacters(WMTProblem):
     return problem.SpaceID.DE_CHR
 
 
-def zhen_wordpiece_token_bigenerator(data_dir, tmp_dir, train,
-                                     source_vocab_size, target_vocab_size):
-  """Wordpiece generator for the WMT'17 zh-en dataset."""
-  datasets = _ZHEN_TRAIN_DATASETS if train else _ZHEN_TEST_DATASETS
-  source_datasets = [[item[0], [item[1][0]]] for item in _ZHEN_TRAIN_DATASETS]
-  target_datasets = [[item[0], [item[1][1]]] for item in _ZHEN_TRAIN_DATASETS]
-  source_vocab = generator_utils.get_or_generate_vocab(
-      data_dir, tmp_dir, "vocab.zh.%d" % source_vocab_size,
-      source_vocab_size, source_datasets)
-  target_vocab = generator_utils.get_or_generate_vocab(
-      data_dir, tmp_dir, "vocab.en.%d" % target_vocab_size,
-      target_vocab_size, target_datasets)
-  tag = "train" if train else "dev"
-  data_path = _compile_data(tmp_dir, datasets, "wmt_zhen_tok_%s" % tag)
-  return bi_vocabs_token_generator(data_path + ".lang1", data_path + ".lang2",
-                                   source_vocab, target_vocab, EOS)
-
-
-def zhen_wordpiece_token_generator(data_dir, tmp_dir, train, vocab_size):
-  return zhen_wordpiece_token_bigenerator(data_dir, tmp_dir, train,
-                                          vocab_size, vocab_size)
-
-
 @registry.register_problem("wmt_zhen_tokens_8k")
 class WMTZhEnTokens8k(WMTProblem):
   """Problem spec for WMT Zh-En translation."""
@@ -507,9 +485,22 @@ class WMTZhEnTokens8k(WMTProblem):
   def targeted_vocab_size(self):
     return 2**13  # 8192
 
-  @property
-  def train_generator(self):
-    return zhen_wordpiece_token_generator
+  def train_generator(self, data_dir, tmp_dir, train):
+    source_vocab_size = self.targeted_vocab_size
+    target_vocab_size = self.targeted_vocab_size
+    datasets = _ZHEN_TRAIN_DATASETS if train else _ZHEN_TEST_DATASETS
+    source_datasets = [[item[0], [item[1][0]]] for item in datasets]
+    target_datasets = [[item[0], [item[1][1]]] for item in datasets]
+    source_vocab = generator_utils.get_or_generate_vocab(
+        data_dir, tmp_dir, "vocab.zh.%d" % source_vocab_size, source_vocab_size,
+        source_datasets)
+    target_vocab = generator_utils.get_or_generate_vocab(
+        data_dir, tmp_dir, "vocab.en.%d" % target_vocab_size, target_vocab_size,
+        target_datasets)
+    tag = "train" if train else "dev"
+    data_path = _compile_data(tmp_dir, datasets, "wmt_zhen_tok_%s" % tag)
+    return bi_vocabs_token_generator(data_path + ".lang1", data_path + ".lang2",
+                                    source_vocab, target_vocab, EOS)
 
   @property
   def input_space_id(self):
@@ -541,17 +532,6 @@ class WMTZhEnTokens32k(WMTZhEnTokens8k):
     return 2**15  # 32768
 
 
-def enfr_wordpiece_token_generator(data_dir, tmp_dir, train, vocab_size):
-  """Instance of token generator for the WMT en->fr task."""
-  symbolizer_vocab = generator_utils.get_or_generate_vocab(
-      data_dir, tmp_dir, "vocab.endefr.%d" % vocab_size, vocab_size)
-  datasets = _ENFR_TRAIN_DATASETS if train else _ENFR_TEST_DATASETS
-  tag = "train" if train else "dev"
-  data_path = _compile_data(tmp_dir, datasets, "wmt_enfr_tok_%s" % tag)
-  return token_generator(data_path + ".lang1", data_path + ".lang2",
-                         symbolizer_vocab, EOS)
-
-
 @registry.register_problem("wmt_enfr_tokens_8k")
 class WMTEnFrTokens8k(WMTProblem):
   """Problem spec for WMT En-Fr translation."""
@@ -560,9 +540,13 @@ class WMTEnFrTokens8k(WMTProblem):
   def targeted_vocab_size(self):
     return 2**13  # 8192
 
-  @property
-  def train_generator(self):
-    return enfr_wordpiece_token_generator
+  def train_generator(self, tmp_dir, train):
+    symbolizer_vocab = generator_utils.get_or_generate_vocab(
+        data_dir, tmp_dir, self.vocab_file, self.targeted_vocab_size)
+    datasets = _ENFR_TRAIN_DATASETS if train else _ENFR_TEST_DATASETS
+    tag = "train" if train else "dev"
+    data_path = _compile_data(tmp_dir, datasets, "wmt_enfr_tok_%s" % tag)
+    return token_generator(data_path + ".lang1", data_path + ".lang2", symbolizer_vocab, EOS)
 
   @property
   def input_space_id(self):
@@ -581,16 +565,6 @@ class WMTEnFrTokens32k(WMTEnFrTokens8k):
     return 2**15  # 32768
 
 
-def enfr_character_generator(tmp_dir, train):
-  """Instance of character generator for the WMT en->fr task."""
-  character_vocab = text_encoder.ByteTextEncoder()
-  datasets = _ENFR_TRAIN_DATASETS if train else _ENFR_TEST_DATASETS
-  tag = "train" if train else "dev"
-  data_path = _compile_data(tmp_dir, datasets, "wmt_enfr_chr_%s" % tag)
-  return character_generator(data_path + ".lang1", data_path + ".lang2",
-                             character_vocab, EOS)
-
-
 @registry.register_problem("wmt_enfr_characters")
 class WMTEnFrCharacters(WMTProblem):
   """Problem spec for WMT En-Fr translation."""
@@ -599,9 +573,13 @@ class WMTEnFrCharacters(WMTProblem):
   def is_character_level(self):
     return True
 
-  @property
-  def train_generator(self):
-    return enfr_character_generator
+  def train_generator(self, data_dir, tmp_dir, train):
+    character_vocab = text_encoder.ByteTextEncoder()
+    datasets = _ENFR_TRAIN_DATASETS if train else _ENFR_TEST_DATASETS
+    tag = "train" if train else "dev"
+    data_path = _compile_data(tmp_dir, datasets, "wmt_enfr_chr_%s" % tag)
+    return character_generator(data_path + ".lang1", data_path + ".lang2",
+                                character_vocab, EOS)
 
   @property
   def input_space_id(self):
@@ -610,20 +588,6 @@ class WMTEnFrCharacters(WMTProblem):
   @property
   def target_space_id(self):
     return problem.SpaceID.FR_CHR
-
-
-def mken_wordpiece_token_generator(data_dir, tmp_dir, train, vocab_size):
-  """Wordpiece generator for the SETimes Mk-En dataset."""
-  datasets = _MKEN_TRAIN_DATASETS if train else _MKEN_TEST_DATASETS
-  source_datasets = [[item[0], [item[1][0]]] for item in _MKEN_TRAIN_DATASETS]
-  target_datasets = [[item[0], [item[1][1]]] for item in _MKEN_TRAIN_DATASETS]
-  symbolizer_vocab = generator_utils.get_or_generate_vocab(
-      data_dir, tmp_dir, "vocab.mken.%d" % vocab_size, vocab_size,
-      source_datasets + target_datasets)
-  tag = "train" if train else "dev"
-  data_path = _compile_data(tmp_dir, datasets, "setimes_mken_tok_%s" % tag)
-  return token_generator(data_path + ".lang1", data_path + ".lang2",
-                         symbolizer_vocab, EOS)
 
 
 @registry.register_problem("setimes_mken_tokens_32k")
@@ -635,8 +599,20 @@ class SETimesMkEnTokens32k(WMTProblem):
     return 2**15  # 32768
 
   @property
-  def train_generator(self):
-    return mken_wordpiece_token_generator
+  def vocab_name(self):
+    return "vocab.mken"
+
+  def train_generator(self, data_dir, tmp_dir, train):
+    datasets = _MKEN_TRAIN_DATASETS if train else _MKEN_TEST_DATASETS
+    source_datasets = [[item[0], [item[1][0]]] for item in datasets]
+    target_datasets = [[item[0], [item[1][1]]] for item in datasets]
+    symbolizer_vocab = generator_utils.get_or_generate_vocab(
+        data_dir, tmp_dir, self.vocab_file, self.targeted_vocab_size,
+        source_datasets + target_datasets)
+    tag = "train" if train else "dev"
+    data_path = _compile_data(tmp_dir, datasets, "setimes_mken_tok_%s" % tag)
+    return token_generator(data_path + ".lang1", data_path + ".lang2",
+                            symbolizer_vocab, EOS)
 
   @property
   def input_space_id(self):
@@ -646,7 +622,65 @@ class SETimesMkEnTokens32k(WMTProblem):
   def target_space_id(self):
     return problem.SpaceID.EN_TOK
 
+@registry.register_problem("wmt_encs_tokens_32k")
+class WMTEnCsTokens32k(problem.Problem):
+  """Problem spec for WMT English-Czech translation."""
 
+  @property
+  def target_vocab_size(self):
+    return 2**15  # 32768
+
+  @property
+  def vocab_name(self):
+    return "vocab.encs"
+
+  def train_generator(self, data_dir, tmp_dir, train):
+    datasets = _ENCS_TRAIN_DATASETS if train else _ENCS_TEST_DATASETS
+    source_datasets = [[item[0], [item[1][0]]] for item in datasets]
+    target_datasets = [[item[0], [item[1][1]]] for item in datasets]
+    symbolizer_vocab = generator_utils.get_or_generate_vocab(
+        data_dir, tmp_dir, self.vocab_file, self.targeted_vocab_size,
+        source_datasets + target_datasets)
+    tag = "train" if train else "dev"
+    data_path = _compile_data(tmp_dir, datasets, "wmt_encs_tok_%s" % tag)
+    return token_generator(data_path + ".lang1", data_path + ".lang2",
+                            symbolizer_vocab, EOS)
+
+  @property
+  def input_space_id(self):
+    return problem.SpaceID.EN_TOK
+
+  @property
+  def target_space_id(self):
+    return problem.SpaceID.CS_TOK
+
+
+@registry.register_problem("wmt_encs_characters")
+class WMTEnCsCharacters(WMTProblem):
+  """Problem spec for WMT En-Cs character-based translation."""
+
+  @property
+  def is_character_level(self):
+    return True
+
+  def train_generator(self, data_dir, tmp_dir, train):
+    character_vocab = text_encoder.ByteTextEncoder()
+    datasets = _ENCS_TRAIN_DATASETS if train else _ENCS_TEST_DATASETS
+    tag = "train" if train else "dev"
+    data_path = _compile_data(tmp_dir, datasets, "wmt_encs_chr_%s" % tag)
+    return character_generator(data_path + ".lang1", data_path + ".lang2",
+                                character_vocab, EOS)
+
+  @property
+  def input_space_id(self):
+    return problem.SpaceID.EN_CHR
+
+  @property
+  def target_space_id(self):
+    return problem.SpaceID.CS_CHR
+
+
+# TODO This function is not used anywhere.
 def parsing_character_generator(tmp_dir, train):
   character_vocab = text_encoder.ByteTextEncoder()
   filename = "parsing_%s" % ("train" if train else "dev")


### PR DESCRIPTION
* simplify wmt.py:
`train_generator` is now a method (not a property returning a function)
and WMTProblem subclasses implement it directly (not via one-purpose functions)
* add WMT English-Czech translation problems
* introduce `vocab_name` property, so e.g. `tokens.vocab-en-cs.32768` is used instead of `tokens.vocab.32768` if only English+Czech datasets were used