### PR TITLE
use s.endswith() where appropriate

### DIFF
--- a/tensor2tensor/data_generators/generator_utils.py
+++ b/tensor2tensor/data_generators/generator_utils.py
@@ -286,7 +286,7 @@ def get_or_generate_vocab(data_dir, tmp_dir,
 
       # Use Tokenizer to count the word occurrences.
       with tf.gfile.GFile(filepath, mode="r") as source_file:
-        file_byte_budget = 3.5e5 if "en" in filepath else 7e5
+        file_byte_budget = 3.5e5 if filepath.endswith("en") else 7e5
         for line in source_file:
           if file_byte_budget <= 0:
             break

--- a/tensor2tensor/data_generators/wmt.py
+++ b/tensor2tensor/data_generators/wmt.py
@@ -397,14 +397,14 @@ def _compile_data(tmp_dir, datasets, filename):
           generator_utils.maybe_download(tmp_dir, compressed_filename, url)
         if not (os.path.exists(lang1_filepath) and
                 os.path.exists(lang2_filepath)):
-          mode = "r:gz" if "gz" in compressed_filepath else "r"
+          mode = "r:gz" if compressed_filepath.endswith("gz") else "r"  # *.tgz *.tar.gz
           with tarfile.open(compressed_filepath, mode) as corpus_tar:
             corpus_tar.extractall(tmp_dir)
-        if ".gz" in lang1_filepath:
+        if lang1_filepath.endswith(".gz"):
           new_filepath = lang1_filepath.strip(".gz")
           generator_utils.gunzip_file(lang1_filepath, new_filepath)
           lang1_filepath = new_filepath
-        if ".gz" in lang2_filepath:
+        if lang2_filepath.endswith(".gz"):
           new_filepath = lang2_filepath.strip(".gz")
           generator_utils.gunzip_file(lang2_filepath, new_filepath)
           lang2_filepath = new_filepath


### PR DESCRIPTION
Most translation language pairs involve English
and both the source and target filenames contain substring "en"
(e.g. europarl-v7.de-en.de), so
`if "en" in filepath` was always evaluated as True.