### PR TITLE
Update YellowFin Optimizer

### DIFF
--- a/tensor2tensor/utils/yellowfin.py
+++ b/tensor2tensor/utils/yellowfin.py
@@ -20,19 +20,18 @@ from __future__ import division
 from __future__ import print_function
 
 # Dependency imports
-
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.framework import ops
 
 
 # Values for gate_gradients.
-GATE_NONE = 0
-GATE_OP = 1
-GATE_GRAPH = 2
+GATE_NONE = tf.train.Optimizer.GATE_NONE
+GATE_OP = tf.train.Optimizer.GATE_OP
+GATE_GRAPH = tf.train.Optimizer.GATE_GRAPH
 
 
-class YellowFinOptimizer(tf.train.Optimizer):
+class YellowFinOptimizer(object):
   """Optimizer that implements the YellowFin algorithm.
 
   See [Zhang et. al., 2017](https://arxiv.org/abs/1706.03471) for details.
@@ -45,20 +44,37 @@ class YellowFinOptimizer(tf.train.Optimizer):
                beta=0.999,
                curvature_window_width=20,
                zero_debias=True,
-               delta_mu=0.0):
+               delta_mu=0.0,
+               sparsity_debias=True,
+               use_locking=False,
+               name="YellowFin",
+               use_nesterov=False):
     """Construct a new YellowFin optimizer.
+    Implemented as a wrapper around tf.train.MomentumOptimizer
 
     Args:
       learning_rate: A Tensor or a floating point value.  The learning rate.
+        Set to 1.0 in the paper.
       momentum: A Tensor or a floating point value.  The momentum.
+         Set to 0.0 in the paper.
       clip_thresh: A Tensor or a floating point value. The cliping threshold for
-        tf.clip_by_global_norm.  If None, no clipping will be carried out.
+        `tf.clip_by_global_norm`.  If None, no clipping will be carried out.
       beta: A float value or a constant float tensor.  The smoothing parameter
         for estimations.
       curvature_window_width: A int value or a constant int tensor.
         The curvature window width.
       zero_debias: A boolean, zero debias moving-averages.
       delta_mu: For extensions. Not necessary in the basic use.
+      sparsity_debias: A boolean. Gradient norm and curvature are
+        biased to larger values when calculated with sparse gradient.
+        This is useful when the model is very sparse, e.g. LSTM with
+        word embedding. For non-sparse CNN, turning it off could
+        slightly accelerate the speed.
+      use_locking: If True, use locks for update operations.
+      name: Optional name prefix for the operations created when
+        applying gradients. Defaults to "YellowFin".
+      use_nesterov: If True, the underlying MomentumOptimizer uses Nesterov
+        Momentum. Set to False in the default YellowFin algorithm.
 
     Note:
       clip_thresh is the threshold value on ||lr * gradient||,
@@ -81,27 +97,44 @@ class YellowFinOptimizer(tf.train.Optimizer):
     self._mu = momentum
 
     # Set lr and mu tensor.
-    self._lr_var = tf.Variable(learning_rate,
-                               dtype=tf.float32,
-                               name="YF_lr",
-                               trainable=False)
-    self._mu_var = tf.Variable(momentum,
-                               dtype=tf.float32,
-                               name="YF_mu",
-                               trainable=False)
+    # self._lr_var = tf.Variable(learning_rate,
+    #                            dtype=tf.float32,
+    #                            name="YF_lr",
+    #                            trainable=False)
+    self._lr_var = tf.get_variable("YF_lr",
+                                   dtype=tf.float32,
+                                   trainable=False,
+                                   initializer=learning_rate)
+
+    # self._mu_var = tf.Variable(momentum,
+    #                            dtype=tf.float32,
+    #                            name="YF_mu",
+    #                            trainable=False)
+    self._mu_var = tf.get_variable("YF_mu",
+                                   dtype=tf.float32,
+                                   trainable=False,
+                                   initializer=tf.constant(momentum))
 
     # Tuning factor for learning rates step or decaying scheme.
-    self.lr_factor = tf.Variable(1.0,
-                                 dtype=tf.float32,
-                                 name="YF_lr_factor",
-                                 trainable=False)
+    # self.lr_factor = tf.Variable(1.0,
+    #                              dtype=tf.float32,
+    #                              name="YF_lr_factor",
+    #                              trainable=False)
+    self.lr_factor = tf.get_variable("YF_lr_factor",
+                                     dtype=tf.float32,
+                                     trainable=False,
+                                     initializer=tf.constant(1.0))
 
     # Gradient Clipping Threshold.
     if clip_thresh is not None:
-      self._clip_thresh_var = tf.Variable(clip_thresh,
-                                          dtype=tf.float32,
-                                          name="YF_clip_thresh",
-                                          trainable=False)
+      # self._clip_thresh_var = tf.Variable(clip_thresh,
+      #                                     dtype=tf.float32,
+      #                                     name="YF_clip_thresh",
+      #                                     trainable=False)
+      self._clip_thresh_var = tf.get_variable("YF_clip_thresh",
+                                              dtype=tf.float32,
+                                              trainable=False,
+                                              initializer=tf.constant(clip_thresh))
     else:
       self._clip_thresh_var = None
 
@@ -111,17 +144,22 @@ class YellowFinOptimizer(tf.train.Optimizer):
 
     # Init momentum optimizer.
     self._momentum_optimizer = tf.train.MomentumOptimizer(
-        self._lr_m, self._mu_m)
+        self._lr_m, self._mu_m, use_locking, name, use_nesterov)
 
     # Moving average for statistics.
     self._beta = beta
     self._moving_averager = None
 
     # Step counting.
-    self._step = tf.Variable(0,
-                             dtype=tf.int32,
-                             name="YF_step",
-                             trainable=False)
+    # self._step = tf.Variable(0,
+    #                          dtype=tf.int32,
+    #                          name="YF_step",
+    #                          trainable=False)
+    self._step = tf.get_variable("YF_step",
+                                 dtype=tf.int32,
+                                 trainable=False,
+                                 initializer=tf.constant(0))
+
     # YF_step + 1 op.
     self._increment_step_op = None
 
@@ -130,6 +168,7 @@ class YellowFinOptimizer(tf.train.Optimizer):
 
     # Moving-averages.
     self._zero_debias = zero_debias
+    self._sparsity_debias = sparsity_debias
 
     # For curvature range.
     self.curvature_window_width = curvature_window_width
@@ -170,27 +209,33 @@ class YellowFinOptimizer(tf.train.Optimizer):
     # and (zero_devias) moving-averages.
     self._moving_averager = None
 
+
   def _curvature_range(self):
     """Curvature range.
 
     Returns:
       h_max_t, h_min_t ops
     """
-    self._curv_win = tf.Variable(np.zeros([self.curvature_window_width,]),
-                                 dtype=tf.float32,
-                                 name="curv_win",
-                                 trainable=False)
-
+    # self._curv_win = tf.Variable(np.zeros([self.curvature_window_width,]),
+    #                              dtype=tf.float32,
+    #                              name="curv_win",
+    #                              trainable=False)
+    self._curv_win = tf.get_variable("curv_win",
+                                     dtype=tf.float32,
+                                     trainable=False,
+                                     shape=[self.curvature_window_width, ],
+                                     initializer=tf.zeros_initializer)
+    # We use log smoothing for curvature range
     self._curv_win = tf.scatter_update(self._curv_win,
                                        self._step % self.curvature_window_width,
-                                       self._grad_norm_squared)
+                                       tf.log(self._grad_norm_squared))
     # Note here the iterations start from iteration 0
     valid_window = tf.slice(self._curv_win,
                             tf.constant([0,]),
                             tf.expand_dims(
                                 tf.minimum(
                                     tf.constant(self.curvature_window_width),
-                                    self._step + 1), axis=0))
+                                    self._step + 1), dim=0))
     self._h_min_t = tf.reduce_min(valid_window)
     self._h_max_t = tf.reduce_max(valid_window)
 
@@ -198,10 +243,16 @@ class YellowFinOptimizer(tf.train.Optimizer):
     with tf.control_dependencies([self._h_min_t, self._h_max_t]):
       avg_op = self._moving_averager.apply([self._h_min_t, self._h_max_t])
       with tf.control_dependencies([avg_op]):
-        self._h_min = tf.identity(self._moving_averager.average(self._h_min_t))
-        self._h_max = tf.identity(self._moving_averager.average(self._h_max_t))
+        self._h_min = tf.exp(
+          tf.identity(self._moving_averager.average(self._h_min_t)))
+        self._h_max = tf.exp(
+          tf.identity(self._moving_averager.average(self._h_max_t)))
+        if self._sparsity_debias:
+          self._h_min = self._h_min * self._sparsity_avg
+          self._h_max = self._h_max * self._sparsity_avg
     curv_range_ops.append(avg_op)
     return curv_range_ops  # h_max_t, h_min_t
+
 
   def _grad_variance(self):
     """Estimate of gradient Variance.
@@ -212,7 +263,7 @@ class YellowFinOptimizer(tf.train.Optimizer):
     grad_var_ops = []
     tensor_to_avg = []
     for t, g in zip(self._vars, self._grad):
-      if isinstance(g, tf.IndexedSlices):
+      if isinstance(g, ops.IndexedSlices):
         tensor_to_avg.append(
             tf.reshape(tf.unsorted_segment_sum(g.values,
                                                g.indices,
@@ -226,11 +277,16 @@ class YellowFinOptimizer(tf.train.Optimizer):
       self._grad_avg = [self._moving_averager.average(val)
                         for val in tensor_to_avg]
       self._grad_avg_squared = [tf.square(val) for val in self._grad_avg]
-      self._grad_avg_squared = tf.add_n([tf.reduce_sum(val)
-                                         for val in self._grad_avg_squared])
+
     # Compute Variance
-    self._grad_var = self._grad_norm_squared_avg - self._grad_avg_squared
+    self._grad_var = tf.maximum(
+      tf.constant(1e-6, dtype=self._grad_norm_squared_avg.dtype),
+      self._grad_norm_squared_avg
+      - tf.add_n([tf.reduce_sum(val) for val in self._grad_avg_squared]))
+    if self._sparsity_debias:
+      self._grad_var *= self._sparsity_avg
     return grad_var_ops  # C_t
+
 
   def _dist_to_opt(self):
     """Distance to optimum.
@@ -239,7 +295,7 @@ class YellowFinOptimizer(tf.train.Optimizer):
       D_t ops
     """
     dist_to_opt_ops = []
-    # Running average of the norm of gradeint
+    # Running average of the norm of gradient
     self._grad_norm = tf.sqrt(self._grad_norm_squared)
     avg_op = self._moving_averager.apply([self._grad_norm,])
     dist_to_opt_ops.append(avg_op)
@@ -254,7 +310,27 @@ class YellowFinOptimizer(tf.train.Optimizer):
     with tf.control_dependencies([avg_op]):
       self._dist_to_opt_avg = tf.identity(
           self._moving_averager.average(self._d_t))
+      if self._sparsity_debias:
+        self._dist_to_opt_avg /= tf.sqrt(self._sparsity_avg)
     return dist_to_opt_ops  # D_t
+
+
+  def _grad_sparsity(self):
+    # If the sparse minibatch gradient has 10 percent of its entries
+    # non-zero, its sparsity is 0.1.
+    # The norm of dense gradient averaged from full dataset
+    # are roughly estimated norm of minibatch
+    # sparse gradient norm * sqrt(sparsity)
+    # An extension maybe only correct the sparse blob.
+    non_zero_cnt = tf.add_n([tf.count_nonzero(g) for g in self._grad])
+    all_entry_cnt = tf.add_n([tf.size(g) for g in self._grad])
+    self._sparsity = tf.cast(non_zero_cnt, self._grad[0].dtype) \
+      / tf.cast(all_entry_cnt, self._grad[0].dtype)
+    avg_op = self._moving_averager.apply([self._sparsity, ])
+    with tf.control_dependencies([avg_op]):
+      self._sparsity_avg = self._moving_averager.average(self._sparsity)
+    return avg_op
+
 
   def _prepare_variables(self):
     """Prepare Variables for YellowFin.
@@ -264,7 +340,7 @@ class YellowFinOptimizer(tf.train.Optimizer):
     """
     self._moving_averager = tf.train.ExponentialMovingAverage(
         decay=self._beta, zero_debias=self._zero_debias)
-    assert self._grad
+    # assert self._grad is not None and len(self._grad) > 0
     # List for the returned Operations
     prepare_variables_op = []
 
@@ -282,6 +358,10 @@ class YellowFinOptimizer(tf.train.Optimizer):
     self._grad_norm_squared = [tf.reduce_sum(g_sq)
                                for g_sq in self._grad_squared]
 
+    if self._sparsity_debias:
+      avg_op_sparsity = self._grad_sparsity()
+      prepare_variables_op.append(avg_op_sparsity)
+
     # The following running average on squared norm of gradient
     # is shared by grad_var and dist_to_opt
     avg_op = self._moving_averager.apply(self._grad_norm_squared)
@@ -295,6 +375,38 @@ class YellowFinOptimizer(tf.train.Optimizer):
     prepare_variables_op.append(avg_op)
     return tf.group(*prepare_variables_op)
 
+
+  def _get_cubic_root(self):
+    # We have the equation x^2 D^2 + (1-x)^4 * C / h_min^2
+    # where x = sqrt(mu).
+    # We substitute x, which is sqrt(mu), with x = y + 1.
+    # It gives y^3 + py = q
+    # where p = (D^2 h_min^2)/(2*C) and q = -p.
+    # We use the Vieta's substution to compute the root.
+    # There is only one real solution y (which is in [0, 1] ).
+    # http://mathworld.wolfram.com/VietasSubstitution.html
+    assert_array = \
+      [tf.Assert(
+        tf.logical_not(tf.is_nan(self._dist_to_opt_avg)), [self._dist_to_opt_avg, ]),
+      tf.Assert(
+        tf.logical_not(tf.is_nan(self._h_min)), [self._h_min,]),
+      tf.Assert(
+        tf.logical_not(tf.is_nan(self._grad_var)), [self._grad_var,]),
+      tf.Assert(
+        tf.logical_not(tf.is_inf(self._dist_to_opt_avg)), [self._dist_to_opt_avg, ]),
+      tf.Assert(
+        tf.logical_not(tf.is_inf(self._h_min)), [self._h_min,]),
+      tf.Assert(
+        tf.logical_not(tf.is_inf(self._grad_var)), [self._grad_var,])]
+    with tf.control_dependencies(assert_array):
+      p = self._dist_to_opt_avg**2 * self._h_min**2 / 2 / self._grad_var
+      w3 = (-tf.sqrt(p**2 + 4.0 / 27.0 * p**3) - p) / 2.0
+      w = tf.sign(w3) * tf.pow(tf.abs(w3), 1.0/3.0)
+      y = w - p / 3.0 / w
+      x = y + 1
+    return x
+
+
   def _get_lr_tensor(self):
     """Get lr minimzing the surrogate.
 
@@ -304,39 +416,19 @@ class YellowFinOptimizer(tf.train.Optimizer):
     lr = (1.0 - tf.sqrt(self._mu))**2 / self._h_min
     return lr
 
+
   def _get_mu_tensor(self):
     """Get the min mu which minimize the surrogate.
 
     Returns:
       The mu_t.
     """
-    const_fact = self._dist_to_opt_avg**2 * self._h_min**2 / 2 / self._grad_var
-    coef = tf.Variable([-1.0, 3.0, 0.0, 1.0],
-                       dtype=tf.float32,
-                       name="cubic_solver_coef")
-    coef = tf.scatter_update(coef,
-                             tf.constant(2),
-                             -(3 + const_fact))
-    roots = tf.py_func(np.roots,
-                       [coef],
-                       Tout=tf.complex64,
-                       stateful=False)
-
-    # Filter out the correct root
-    root_idx = tf.logical_and(
-        tf.logical_and(
-            tf.greater(tf.real(roots), tf.constant(0.0)),
-            tf.less(tf.real(roots), tf.constant(1.0))),
-        tf.less(tf.abs(tf.imag(roots)), 1e-5))
-
-    # In case there are two duplicated roots satisfying the above condition
-    root = tf.reshape(tf.gather(tf.gather(roots, tf.where(root_idx)),
-                                tf.constant(0)),
-                      shape=[])
-
+    root = self._get_cubic_root()
     dr = self._h_max / self._h_min
-    mu = tf.maximum(tf.real(root)**2, ((tf.sqrt(dr) - 1)/(tf.sqrt(dr) + 1))**2)
+    mu = tf.maximum(
+      root**2, ((tf.sqrt(dr) - 1) / (tf.sqrt(dr) + 1))**2)
     return mu
+
 
   def _yellowfin(self):
     """YellowFin auto-tuning optimizer based on momentum SGD.
@@ -366,11 +458,12 @@ class YellowFinOptimizer(tf.train.Optimizer):
     # squared distance from the optimum of a local quadratic
     # approximation after a single step while keeping all directions in the
     # robust region.
-    self._mu = tf.identity(tf.cond(self._do_tune, self._get_mu_tensor,
+    self._mu = tf.identity(tf.cond(self._do_tune,
+                                   lambda: self._get_mu_tensor(),
                                    lambda: self._mu_var))
     with tf.control_dependencies([self._mu]):
       self._lr = tf.identity(tf.cond(self._do_tune,
-                                     self._get_lr_tensor,
+                                     lambda: self._get_lr_tensor(),
                                      lambda: self._lr_var))
 
     # Tune learning rate and momentum.
@@ -382,6 +475,11 @@ class YellowFinOptimizer(tf.train.Optimizer):
 
     yellowfin_ops = tf.group(*yellowfin_ops)
     return yellowfin_ops
+
+
+  def get_name(self):
+    return self._optimizer.get_name()
+
 
   def apply_gradients(self, grads_and_vars, global_step=None, name=None):
     """Applying gradients aand tune hyperparams with YellowFin.
@@ -413,14 +511,20 @@ class YellowFinOptimizer(tf.train.Optimizer):
             self._grad, self._clip_thresh_var)
 
         apply_grad_op = self._momentum_optimizer.apply_gradients(
-            zip(self._grads_clip, self._vars), global_step=global_step)
+            zip(self._grads_clip, self._vars), global_step=global_step, name=name)
       else:
         apply_grad_op = self._momentum_optimizer.apply_gradients(
-            zip(self._grad, self._vars), global_step=global_step)
+            zip(self._grad, self._vars), global_step=global_step, name=name)
 
     # Begin lr and mu tuning.
     with tf.variable_scope("prepare_yellowFin_variables"):
-      prepare_variables_op = self._prepare_variables()
+      # the dependencies ideally only need to be after clip is done,
+      # i.e. dependes on self._grads. However, the control_dependencies
+      # does not support indexed slice for sparse gradients.
+      # The alternative dependencies here might be slightly slower due
+      # to less parallelization.
+      with tf.control_dependencies([apply_grad_op, ]):
+        prepare_variables_op = self._prepare_variables()
 
     with tf.variable_scope("yellowfin"):
       with tf.control_dependencies([prepare_variables_op]):
@@ -434,6 +538,7 @@ class YellowFinOptimizer(tf.train.Optimizer):
                     prepare_variables_op,
                     yellowfin_op,
                     self._increment_step_op)
+
 
   def compute_gradients(self,
                         loss,
@@ -474,6 +579,7 @@ class YellowFinOptimizer(tf.train.Optimizer):
         aggregation_method=aggregation_method,
         colocate_gradients_with_ops=colocate_gradients_with_ops,
         grad_loss=grad_loss)
+
 
   def minimize(self,
                loss,
@@ -533,4 +639,29 @@ class YellowFinOptimizer(tf.train.Optimizer):
       print("g ", g)
       print("v ", v)
 
-    return self.apply_gradients(grads_and_vars, global_step=global_step)
+    return self.apply_gradients(grads_and_vars, global_step=global_step, name=name)
+
+
+  def get_slot(self, var, name):
+    """
+    Return a slot named `name` created for `var` by
+    the underlying MomentumOptimizer.
+
+    Args:
+      var: A variable passed to `minimize()` or `apply_gradients()`.
+      name: A string.
+
+    Returns:
+      The `Variable` for the slot if it was created, `None` otherwise.
+    """
+    return self._momentum_optimizer.get_slot(var, name)
+
+  def get_slot_names(self):
+    """
+    Return a list of the names of the slots created by the
+    underlying MomentumOptimizer.
+
+    Returns:
+      A list of strings.
+    """
+    return self._momentum_optimizer.get_slot_names()


### PR DESCRIPTION
@lukaszkaiser as promised, i've updated YellowFin, now it works **but only** with TensorFlow 1.3.0.
The problems reside on the `Estimator` API or something related to it because i've retried the old version with TF v.1.3.0 and runs without any errors.
Unfortunately i cannot test it in a distributed environment. 

In all my experiment with T2T v.1.1.19, i've encountered the `CUDA_ERROR_OUT_OF_MEMORY` that i think it was introduced with the last PRs, because i've test the old optimizer with T2T v.1.1.13 and TF v.1.3.0 and i haven't any errors as said here #125  and here #213.