### PR TITLE
Simplify native_to_unicode() & unicode_to_native()

### DIFF
--- a/tensor2tensor/data_generators/text_encoder.py
+++ b/tensor2tensor/data_generators/text_encoder.py
@@ -56,19 +56,18 @@ _UNESCAPE_REGEX = re.compile(r"\\u|\\\\|\\([0-9]+);")
 _ESCAPE_CHARS = set(u"\\_u;0123456789")
 
 
-def native_to_unicode_py2(s):
-  """Python 2: transform native string to Unicode."""
-  return s if isinstance(s, unicode) else s.decode("utf8")
+def native_to_unicode(s):
+  """Transform native string to Unicode."""
+  try:               # Python 2
+    return s if isinstance(s, unicode) else s.decode("utf8")
+  except NameError:  # Python 3: unicode() was dropped
+    return s
 
 
 # Conversion between Unicode and UTF-8, if required (on Python2)
-if six.PY2:
-  native_to_unicode = native_to_unicode_py2
-  unicode_to_native = lambda s: s.encode("utf-8")
-else:
-  # No conversion required on Python3
-  native_to_unicode = lambda s: s
-  unicode_to_native = lambda s: s
+def unicode_to_native(s):
+  """Transform Unicode to native string."""
+  return s.encode("utf-8") if six.PY2 else s  # No conversion required on Python3
 
 
 class TextEncoder(object):

--- a/tensor2tensor/data_generators/text_encoder.py
+++ b/tensor2tensor/data_generators/text_encoder.py
@@ -56,18 +56,13 @@ _UNESCAPE_REGEX = re.compile(r"\\u|\\\\|\\([0-9]+);")
 _ESCAPE_CHARS = set(u"\\_u;0123456789")
 
 
-def native_to_unicode(s):
-  """Transform native string to Unicode."""
-  try:               # Python 2
-    return s if isinstance(s, unicode) else s.decode("utf8")
-  except NameError:  # Python 3: unicode() was dropped
-    return s
-
-
-# Conversion between Unicode and UTF-8, if required (on Python2)
-def unicode_to_native(s):
-  """Transform Unicode to native string."""
-  return s.encode("utf-8") if six.PY2 else s  # No conversion required on Python3
+if six.PY2:
+  def native_to_unicode(s): return s if isinstance(s, unicode) else s.decode("utf8")  # noqa: F821
+  def unicode_to_native(s): return s.encode("utf-8")
+else:
+  # No conversion required on Python >= 3
+  def native_to_unicode(s): return s
+  def unicode_to_native(s): return s
 
 
 class TextEncoder(object):


### PR DESCRIPTION
The first [uses feature detection, instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection) and the second [avoids assigning a lambda expression to a variable](https://docs.quantifiedcode.com/python-anti-patterns/correctness/assigning_a_lambda_to_a_variable.html).