### PR TITLE
reserve also UNK token, more robust TokenTextEncoder

### DIFF
--- a/tensor2tensor/data_generators/text_encoder.py
+++ b/tensor2tensor/data_generators/text_encoder.py
@@ -38,10 +38,12 @@ import tensorflow as tf
 # Reserved tokens for things like padding and EOS symbols.
 PAD = "<pad>"
 EOS = "<EOS>"
-RESERVED_TOKENS = [PAD, EOS]
+UNK = "<UNK>"
+RESERVED_TOKENS = [PAD, EOS, UNK]
 NUM_RESERVED_TOKENS = len(RESERVED_TOKENS)
 PAD_ID = RESERVED_TOKENS.index(PAD)  # Normally 0
 EOS_ID = RESERVED_TOKENS.index(EOS)  # Normally 1
+UNK_ID = RESERVED_TOKENS.index(UNK)  # Normally 2
 
 if six.PY2:
   RESERVED_TOKENS_BYTES = RESERVED_TOKENS
@@ -171,7 +173,7 @@ class TokenTextEncoder(TextEncoder):
 
   def encode(self, sentence):
     """Converts a space-separated string of tokens to a list of ids."""
-    ret = [self._token_to_id[tok] for tok in sentence.strip().split()]
+    ret = [self._token_to_id.get(tok, UNK_ID) for tok in sentence.strip().split()]
     return ret[::-1] if self._reverse else ret
 
   def decode(self, ids):


### PR DESCRIPTION
TokenTextEncoder is used in data_generators.wmt.ende_bpe_token_generator()
in the translate_ende_wmt_bpe32k problem, which uses an external BPE vocabulary
and training data pre-processed with these BPE subwords.
This may be useful when comparing with Nematus/NeuralMonkey etc. on exactly the same training data.
Unfortunately, the TokenTextEncoder implementation was not robust enough.
It failed if there was an unknown subword in the training or dev or test data,
e.g. because of unknown character.

This PR solves the main problem (failure) for me, but
- UNK tokens are silently ignored without any warning
- NUM_RESERVED_TOKENS is increased, so it may break compatibility with legacy models
  (What about setting NUM_RESERVED_TOKENS high enough for any future use?)

Feel free to close this PR without merging if you don't like it.