### PR TITLE
Add unknown token support to TokenTextEncoder

### DIFF
--- a/tensor2tensor/data_generators/text_encoder_test.py
+++ b/tensor2tensor/data_generators/text_encoder_test.py
@@ -92,6 +92,27 @@ class TokenTextEncoderTest(tf.test.TestCase):
     # be unique.
     self.assertEqual(len(all_tokens), len(set(all_tokens)))
 
+  def test_unknown_token_returned_for_oov_term(self):
+    "Test that unknown token is returned for term not occuring in corpus."
+    unk_token = 'UNK'
+    corpus = 'A B C D E F G H ' + unk_token
+
+    encoder = text_encoder.TokenTextEncoder(None, 
+                                            vocab_list=corpus.split(), 
+                                            unknown_token=unk_token)
+
+    encoded = encoder.encode('H Z')
+    self.assertEqual('H ' + unk_token, encoder.decode(encoded))
+
+  def test_unknown_token_not_in_vocab_raises_error(self):
+    "Test that when vocabulary does not contain unknown token it fails fast."
+    corpus = 'A B C D E F G H'
+
+    with self.assertRaises(Exception):
+      text_encoder.TokenTextEncoder(None, 
+                                    vocab_list=corpus.split(), 
+                                    unknown_token='UNK')
+
 
 class SubwordTextEncoderTest(tf.test.TestCase):
 


### PR DESCRIPTION
I needed to support out-of-vocabulary terms for some NER experiments but like mentioned in #250 the TokenTestEncode would fail on OOV terms. This PR updates TokenTestEncoder to allow problems to specify a token to be returned for OOV terms. 

It is similar to #250 except it allows problems to opt-in by specifying the `unknown_token` parameter and it doesn't add a new reserved token. Since a reserved token is not added it is the problems responsibility to ensure the unknown token exists in the vocabulary.