### PR TITLE
tensor2tensor: xrange(10) --> range(10) for Python 3

### DIFF
--- a/tensor2tensor/utils/diet_test.py
+++ b/tensor2tensor/utils/diet_test.py
@@ -53,7 +53,7 @@ class DietVarTest(tf.test.TestCase):
     with self.test_session() as sess:
       sess.run(tf.global_variables_initializer())
       orig_vals = sess.run(tf.global_variables())
-      for _ in xrange(10):
+      for _ in range(10):
         sess.run(train_op)
       new_vals = sess.run(tf.global_variables())
 


### PR DESCRIPTION
xrange() was removed in Python 3.  For counting to 10, `from six.moves import xrange` would be overkill.