### PR TITLE
Fix key deletion during key iteration in Python 3

### DIFF
--- a/tensor2tensor/utils/model_builder.py
+++ b/tensor2tensor/utils/model_builder.py
@@ -482,6 +482,6 @@ def _learning_rate_decay(hparams, num_worker_replicas=1, num_train_steps=1):
 
 
 def _del_dict_nones(d):
-  for k in d.keys():
+  for k in list(d.keys()):
     if d[k] is None:
       del d[k]


### PR DESCRIPTION
Deletion of dict keys while iterating over said dict is a no-no in Python 3, and RuntimeErrors.  This simply consumes the dict key iterator into a list before iterative deletion.