### PR TITLE
Fixes #311 - Multi-problem models do not work with recent TF

### DIFF
--- a/tensor2tensor/utils/input_fn_builder.py
+++ b/tensor2tensor/utils/input_fn_builder.py
@@ -176,23 +176,14 @@ def _problem_choice(choice_mode, mode, problem_count, loss_moving_avgs,
 def cond_on_index(fn, index_tensor, max_idx, cur_idx=0):
   """Call fn(index_tensor) using tf.cond in [cur_id, max_idx]."""
 
-  # Because tf.cond expects fn to return a flat list of Tensors, we flatten the
-  # output of fn. By capturing the original output here in orig_out, we can pack
-  # the flat sequence into the original structure.
-  orig_out = []
-
-  def wrapped_fn():
-    out = fn(cur_idx)
-    orig_out.append(out)
-    return tf.contrib.framework.nest.flatten(out)
-
   if cur_idx == max_idx:
-    flat_out = wrapped_fn()
-  else:
-    flat_out = tf.cond(
-        tf.equal(index_tensor, cur_idx), wrapped_fn,
-        lambda: cond_on_index(fn, index_tensor, max_idx, cur_idx + 1))
-  return tf.contrib.framework.nest.pack_sequence_as(orig_out[0], flat_out)
+    return fn(cur_idx)
+
+  return tf.cond(
+    tf.equal(index_tensor, cur_idx),
+    lambda: fn(cur_idx),
+    lambda: cond_on_index(fn, index_tensor, max_idx, cur_idx + 1)
+  )
 
 
 class DummyQueueRunner(object):

--- a/tensor2tensor/utils/input_fn_builder_test.py
+++ b/tensor2tensor/utils/input_fn_builder_test.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+# Copyright 2017 The Tensor2Tensor Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tensor2tensor.utils.input_fn_builder."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensor2tensor.utils import input_fn_builder
+import tensorflow as tf
+
+
+class InputFnBuilderTest(tf.test.TestCase):
+
+  def testCondOnIndex(self):
+    """Smoke tests of cond_on_index()"""
+
+    z = tf.constant(1., dtype=tf.float32)
+    def f(n):
+      return {
+        "a": z * n,
+        "b": z * n * n
+      }
+
+    index = tf.placeholder(shape=[], dtype=tf.int32)
+    out = input_fn_builder.cond_on_index(f, index, 3, 0)
+
+    with self.test_session() as sess:
+      # Check dispatching to the correct branch
+      result = sess.run(out, feed_dict={
+        index: 2
+      })
+
+      self.assertAllClose(result["a"], 2.)
+      self.assertAllClose(result["b"], 4.)
+
+      result = sess.run(out, feed_dict={
+        index: 3
+      })
+
+      self.assertAllClose(result["a"], 3.)
+      self.assertAllClose(result["b"], 9.)
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
See issue #311 

Since TF update: https://github.com/tensorflow/tensorflow/commit/3aaf220fef04c1ab71301c4fc76739c6a4df605e
multi-problem runs fail with crash inside `tensor2tensor.input_fn_builder.cond_on_index()`

Fixed by removing flattening trick (no longer needed). Added unit test.