### PR TITLE
fix problem with overriding data_dir flag in trainer_utils. Error…

### DIFF
--- a/tensor2tensor/utils/trainer_utils.py
+++ b/tensor2tensor/utils/trainer_utils.py
@@ -60,7 +60,9 @@ flags.DEFINE_string(
     model.""")
 flags.DEFINE_string("problems", "", "Dash separated list of problems to "
                     "solve.")
-flags.DEFINE_string("data_dir", None, "Directory with training data.")
+#May be already defined in t2t-datagen
+if not FLAGS.data_dir:
+  flags.DEFINE_string("data_dir", None, "Directory with training data.")
 flags.DEFINE_integer("train_steps", 250000,
                      "The number of steps to run training for.")
 flags.DEFINE_bool("eval_run_autoregressive", False,


### PR DESCRIPTION
…: conflicting option string(s): --data_dir
After import trainer utils I started getting error:
```
Traceback (most recent call last):
  File "/usr/local/bin/t2t-datagen", line 213, in <module>
    tf.app.run()
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/platform/app.py", line 48, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "/usr/local/bin/t2t-datagen", line 131, in main
    usr_dir.import_usr_dir(FLAGS.t2t_usr_dir)
  File "/usr/local/lib/python2.7/dist-packages/tensor2tensor/utils/usr_dir.py", line 41, in import_usr_dir
    importlib.import_module(module_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/bogdan/Programming/Tensor2Tensor/__init__.py", line 3, in <module>
    import word2def
  File "/home/bogdan/Programming/Tensor2Tensor/word2def.py", line 3, in <module>
    from tensor2tensor.utils import trainer_utils
  File "/usr/local/lib/python2.7/dist-packages/tensor2tensor/utils/trainer_utils.py", line 66, in <module>
    flags.DEFINE_string("data_dir", "", "Data directory.")
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/platform/flags.py", line 85, in DEFINE_string
    _define_helper(flag_name, default_value, docstring, str)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/platform/flags.py", line 70, in _define_helper
    type=flagtype)
  File "/usr/lib/python2.7/argparse.py", line 1308, in add_argument
    return self._add_action(action)
  File "/usr/lib/python2.7/argparse.py", line 1682, in _add_action
    self._optionals._add_action(action)
  File "/usr/lib/python2.7/argparse.py", line 1509, in _add_action
    action = super(_ArgumentGroup, self)._add_action(action)
  File "/usr/lib/python2.7/argparse.py", line 1322, in _add_action
    self._check_conflict(action)
  File "/usr/lib/python2.7/argparse.py", line 1460, in _check_conflict
    conflict_handler(action, confl_optionals)
  File "/usr/lib/python2.7/argparse.py", line 1467, in _handle_conflict_error
    raise ArgumentError(action, message % conflict_string)
argparse.ArgumentError: argument --data_dir: conflicting option string(s): --data_dir
```
I added hardcoded fix but maybe you should find another solution