### PR TITLE
2-Dims placeholder for tf.VarLenFeature

### DIFF
--- a/tensor2tensor/utils/data_reader.py
+++ b/tensor2tensor/utils/data_reader.py
@@ -44,7 +44,7 @@ def feature_placeholders(data_fields, data_items_to_decoders):
   example = {}
   for field, config in data_fields.items():
     if isinstance(config, tf.VarLenFeature):
-      shape = [None]
+      shape = [None, None]
     else:
       shape = config.shape
 


### PR DESCRIPTION
Currently, the outputted `SavedModel` as decode server, the generated placeholder shape for tf.VarLenFeature will be a `[None]` int array. Then by intuition if we feed with a 1-Dim int array, the input will be transformed to a `[None, 1, 1, 1]` via `tf.expand_dims`. Then the only one int array input is treated as a batched int input, and everything else outputted form model will be crashed.

By adding one rank with undefined dim size to placeholder will fix this.

I tired `transformer`, `transformer_vae`, and `lstm`, all hit this problem, but not sure if all other models are the same. I am not fermilier with all other models and possiblly this change would break other models.