### PR TITLE
fix the semantics of decode_to_file

### DIFF
--- a/tensor2tensor/bin/t2t-decoder
+++ b/tensor2tensor/bin/t2t-decoder
@@ -47,9 +47,8 @@ flags = tf.flags
 FLAGS = flags.FLAGS
 
 flags.DEFINE_string("output_dir", "", "Training directory to load from.")
-flags.DEFINE_string("decode_from_file", None, "Path to decode file")
-flags.DEFINE_string("decode_to_file", None,
-                    "Path prefix to inference output file")
+flags.DEFINE_string("decode_from_file", None, "Path to the source file for decoding")
+flags.DEFINE_string("decode_to_file", None, "Path to the decoded (output) file")
 flags.DEFINE_bool("decode_interactive", False,
                   "Interactive local inference mode.")
 flags.DEFINE_integer("decode_shards", 1, "Number of decoding replicas.")

--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -252,17 +252,14 @@ def decode_from_file(estimator, filename, decode_hp, decode_to_file=None):
   # _decode_batch_input_fn
   sorted_inputs.reverse()
   decodes.reverse()
-  # Dumping inputs and outputs to file filename.decodes in
-  # format result\tinput in the same order as original inputs
-  if decode_to_file:
-    output_filename = decode_to_file
-  else:
-    output_filename = filename
+  # If decode_to_file was provided use it as the output filename without any change
+  # (except for adding shard_id if using more shards for decoding).
+  # Otherwise, use the input filename plus model, hp, problem, beam, alpha.
+  decode_filename = decode_to_file if decode_to_file else filename
   if decode_hp.shards > 1:
-    base_filename = output_filename + ("%.2d" % decode_hp.shard_id)
-  else:
-    base_filename = output_filename
-  decode_filename = _decode_filename(base_filename, problem_name, decode_hp)
+    decode_filename = decode_filename + ("%.2d" % decode_hp.shard_id)
+  if not decode_to_file:
+    decode_filename = _decode_filename(decode_filename, problem_name, decode_hp)
   tf.logging.info("Writing decodes into %s" % decode_filename)
   outfile = tf.gfile.Open(decode_filename, "w")
   for index in range(len(sorted_inputs)):


### PR DESCRIPTION
`--decode_to_file=xy` should use `xy` as the output filename,
not `xy.$MODEL.$HPARAMS.$PROBLEM.beam$BEAM_SIZE.alpha$ALPHA.decodes`.
It is easy for users to add whatever env variables to xy,
but it is impossible to change the hardwired suffix.