### PR TITLE
scripts for proper BLEU evaluation, batch translation and averaging

### DIFF
--- a/tensor2tensor/bin/t2t-avg-all
+++ b/tensor2tensor/bin/t2t-avg-all
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2017 The Tensor2Tensor Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Script to continously average last N checkpoints in a given directory."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import logging
+
+# Dependency imports
+
+import numpy as np
+import six
+from six.moves import zip  # pylint: disable=redefined-builtin
+from collections import deque
+import shutil
+import tensorflow as tf
+from tensor2tensor.utils import bleu_hook
+
+flags = tf.flags
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string("model_dir", "", "Directory to load model checkpoints from.")
+flags.DEFINE_string("output_dir", "avg/", "Directory to output the averaged checkpoints to.")
+flags.DEFINE_integer("n", 8, "How many checkpoints should be averaged?")
+flags.DEFINE_integer("min_steps", 0, "Ignore checkpoints with less steps.")
+flags.DEFINE_integer("wait_minutes", 0, "Wait upto N minutes for a new checkpoint.")
+
+
+def main(_):
+  tf.logging._handler.setFormatter(logging.Formatter("%(asctime)s:" + logging.BASIC_FORMAT, None))
+  tf.logging.set_verbosity(tf.logging.INFO)
+
+  model_dir = os.path.expanduser(FLAGS.model_dir)
+  output_dir = os.path.expanduser(FLAGS.output_dir)
+  out_base_file = os.path.join(output_dir, 'model.ckpt')
+
+  # Copy flags.txt with the original time, so t2t-bleu can report correct relative time.
+  os.makedirs(FLAGS.output_dir, exist_ok=True)
+  if not os.path.exists(os.path.join(output_dir, 'flags.txt')):
+    shutil.copy2(os.path.join(model_dir, 'flags.txt'), os.path.join(output_dir, 'flags.txt'))
+
+  models_processed = 0
+  queue = deque()
+  for model in bleu_hook.stepfiles_iterator(model_dir, FLAGS.wait_minutes, FLAGS.min_steps):
+    if models_processed == 0:
+      var_list = tf.contrib.framework.list_variables(model.filename)
+      avg_values = {}
+      for (name, shape) in var_list:
+        if not name.startswith("global_step"):
+          avg_values[name] = np.zeros(shape)      
+    models_processed += 1
+
+    tf.logging.info("Loading [%d]: %s" % (models_processed, model.filename))
+    reader = tf.contrib.framework.load_checkpoint(model.filename)
+    for name in avg_values:
+      avg_values[name] += reader.get_tensor(name) / FLAGS.n
+    queue.append(model)
+    if len(queue) < FLAGS.n:
+      continue
+
+    out_file = "%s-%d" % (out_base_file, model.steps)
+    tf_vars = []
+    tf.logging.info("Averaging %s" % (out_file))
+    for (name, value) in six.iteritems(avg_values):
+      tf_vars.append(tf.get_variable(name, shape=value.shape)) # TODO , dtype=var_dtypes[name]
+    placeholders = [tf.placeholder(v.dtype, shape=v.shape) for v in tf_vars]
+    assign_ops = [tf.assign(v, p) for (v, p) in zip(tf_vars, placeholders)]
+  
+    global_step = tf.Variable(model.steps, name="global_step", trainable=False, dtype=tf.int64)
+    saver = tf.train.Saver(tf.global_variables())
+
+    tf.logging.info("Running session for %s" % (out_file))
+    with tf.Session() as sess:
+      sess.run(tf.global_variables_initializer())
+      for p, assign_op, (name, value) in zip(placeholders, assign_ops, six.iteritems(avg_values)):
+        sess.run(assign_op, {p: value})
+      tf.logging.info("Storing to %s" % out_file)
+      saver.save(sess, out_base_file, global_step=global_step)
+    os.utime(out_file + '.index', (model.mtime, model.mtime))
+
+    tf.reset_default_graph()
+    first_model = queue.popleft()
+
+    reader = tf.contrib.framework.load_checkpoint(first_model.filename)
+    for name in avg_values:
+      avg_values[name] -= reader.get_tensor(name) / FLAGS.n
+
+
+if __name__ == "__main__":
+  tf.app.run()

--- a/tensor2tensor/bin/t2t-bleu
+++ b/tensor2tensor/bin/t2t-bleu
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2017 The Tensor2Tensor Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Evaluate BLEU score for all checkpoints/translations in a given directory.
+
+This script can be used in two ways.
+
+To evaluate one already translated file:
+`t2t-bleu --translation=my-wmt13.de --reference=wmt13_deen.de`
+
+To evaluate all translations in a given directory (translated by t2t-translate-all):
+`t2t-bleu
+  --translations_dir=my-translations
+  --reference=wmt13_deen.de
+  --event_dir=events`
+
+In addition to the above-mentioned compulsory parameters,
+there are optional parameters:
+
+ * bleu_variant: cased (case-sensitive), uncased, both (default).
+ * tag_suffix: Default="", so the tags will be BLEU_cased and BLEU_uncased. tag_suffix
+   can be used e.g. for different beam sizes if these should be plotted in different graphs.
+ * min_steps: Don't evaluate checkpoints with less steps.
+   Default=-1 means check the `last_evaluated_step.txt` file, which contains the number of steps
+   of the last successfully evaluated checkpoint.
+ * report_zero: Store BLEU=0 and guess its time based on the oldest file in the translations_dir.
+   Default=True. This is useful, so TensorBoard reports correct relative time for the remaining
+   checkpoints. This flag is set to False if min_steps is > 0.
+ * wait_minutes: Wait upto N minutes for a new translated file. Default=0.
+   This is useful for continuous evaluation of a running training,
+   in which case this should be equal to save_checkpoints_secs/60 plus time needed for translation
+   plus some reserve.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+import os
+from tensor2tensor.utils import bleu_hook
+import tensorflow as tf
+
+
+flags = tf.flags
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string("source", None, "Path to the source-language file to be translated")
+flags.DEFINE_string("reference", None, "Path to the reference translation file")
+flags.DEFINE_string("translation", None, "Path to the MT system translation file")
+flags.DEFINE_string("translations_dir", None, "Directory with translated files to be evaulated.")
+flags.DEFINE_string("event_dir", None, "Where to store the event file.")
+
+flags.DEFINE_string("bleu_variant", "both",
+                    "Possible values: cased(case-sensitive), uncased, both(default).")
+flags.DEFINE_string("tag_suffix", "",
+                    "What to add to BLEU_cased and BLEU_uncased tags. Default=''.")
+flags.DEFINE_integer("min_steps", -1, "Don't evaluate checkpoints with less steps.")
+flags.DEFINE_integer("wait_minutes", 0,
+                     "Wait upto N minutes for a new checkpoint, cf. save_checkpoints_secs.")
+flags.DEFINE_bool("report_zero", None, "Store BLEU=0 and guess its time based on the oldest file.")
+
+
+def main(_):
+  tf.logging.set_verbosity(tf.logging.INFO)
+  if FLAGS.translation:
+    if FLAGS.translations_dir:
+      raise ValueError('Cannot specify both --translation and --translations_dir.')
+    if FLAGS.bleu_variant in ('uncased', 'both'):
+      bleu = 100 * bleu_hook.bleu_wrapper(FLAGS.reference, FLAGS.translation, case_sensitive=False)
+      print("BLEU_uncased = %6.2f" % bleu)
+    if FLAGS.bleu_variant in ('cased', 'both'):
+      bleu = 100 * bleu_hook.bleu_wrapper(FLAGS.reference, FLAGS.translation, case_sensitive=True)
+      print("BLEU_cased = %6.2f" % bleu)
+    return
+
+  if not FLAGS.translations_dir:
+    raise ValueError('Either --translation or --translations_dir must be specified.')
+  transl_dir = os.path.expanduser(FLAGS.translations_dir)
+
+  last_step_file = os.path.join(FLAGS.event_dir, 'last_evaluated_step.txt')
+  if FLAGS.min_steps == -1:
+    try:
+      with open(last_step_file) as ls_file:
+        FLAGS.min_steps = int(ls_file.read())
+    except FileNotFoundError:
+      FLAGS.min_steps = 0
+  if FLAGS.report_zero is None:
+    FLAGS.report_zero = FLAGS.min_steps == 0
+
+  writer = tf.summary.FileWriter(FLAGS.event_dir)
+  for transl_file in bleu_hook.stepfiles_iterator(transl_dir, FLAGS.wait_minutes,
+                                                      FLAGS.min_steps, path_suffix=''):
+    # report_zero handling must be inside the for-loop,
+    # so we are sure the transl_dir is already created.
+    if FLAGS.report_zero:
+      all_files = (os.path.join(transl_dir, f) for f in os.listdir(transl_dir))
+      start_time = min(os.path.getmtime(f) for f in all_files if os.path.isfile(f))
+      values = []
+      if FLAGS.bleu_variant in ('uncased', 'both'):
+        values.append(tf.Summary.Value(tag='BLEU_uncased' + FLAGS.tag_suffix, simple_value=0))
+      if FLAGS.bleu_variant in ('cased', 'both'):
+        values.append(tf.Summary.Value(tag='BLEU_cased' + FLAGS.tag_suffix, simple_value=0))
+      writer.add_event(tf.summary.Event(summary=tf.Summary(value=values),
+                                        wall_time=start_time, step=0))
+      FLAGS.report_zero = False
+
+    filename = transl_file.filename
+    tf.logging.info("Evaluating " + filename)
+    values = []
+    if FLAGS.bleu_variant in ('uncased', 'both'):
+      bleu = 100 * bleu_hook.bleu_wrapper(FLAGS.reference, filename, case_sensitive=False)
+      values.append(tf.Summary.Value(tag='BLEU_uncased' + FLAGS.tag_suffix, simple_value=bleu))
+      tf.logging.info("%s: BLEU_uncased = %6.2f" % (filename, bleu))
+    if FLAGS.bleu_variant in ('cased', 'both'):
+      bleu = 100 * bleu_hook.bleu_wrapper(FLAGS.reference, filename, case_sensitive=True)
+      values.append(tf.Summary.Value(tag='BLEU_cased' + FLAGS.tag_suffix, simple_value=bleu))
+      tf.logging.info("%s: BLEU_cased = %6.2f" % (transl_file.filename, bleu))
+    writer.add_event(tf.summary.Event(summary=tf.Summary(value=values),
+                                      wall_time=transl_file.mtime, step=transl_file.steps))
+    writer.flush()
+    with open(last_step_file, 'w') as ls_file:
+      ls_file.write(str(transl_file.steps) + '\n')
+
+
+if __name__ == "__main__":
+  tf.app.run()

--- a/tensor2tensor/bin/t2t-translate-all
+++ b/tensor2tensor/bin/t2t-translate-all
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2017 The Tensor2Tensor Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Translate a file with all checkpoints in a given directory.
+
+t2t-decoder will be executed with these parameters:
+--problems
+--data_dir
+--output_dir with the value of --model_dir
+--decode_from_file with the value of --source
+--decode_hparams with properly formated --beam_size and --alpha
+--checkpoint_path automatically filled
+--decode_to_file automatically filled
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+import os
+import shutil
+import tensorflow as tf
+from tensor2tensor.utils import bleu_hook
+
+
+flags = tf.flags
+
+# t2t-translate-all specific options
+flags.DEFINE_string("decoder_command", "t2t-decoder {params}",
+                    "Which command to execute instead t2t-decoder."
+                    "{params} is replaced by the parameters. Useful e.g. for qsub wrapper.")
+flags.DEFINE_string("model_dir", "", "Directory to load model checkpoints from.")
+flags.DEFINE_string("source", None, "Path to the source-language file to be translated")
+flags.DEFINE_string("translations_dir", "translations", "Where to store the translated files.")
+flags.DEFINE_integer("min_steps", 0, "Ignore checkpoints with less steps.")
+flags.DEFINE_integer("wait_minutes", 0, "Wait upto N minutes for a new checkpoint")
+
+# options derived from t2t-decoder
+flags.DEFINE_integer("beam_size", 4, "Beam-search width.")
+flags.DEFINE_float("alpha", 0.6, "Beam-search alpha.")
+flags.DEFINE_string("model", "transformer", "see t2t-decoder")
+flags.DEFINE_string("t2t_usr_dir", None, "see t2t-decoder")
+flags.DEFINE_string("data_dir", None, "see t2t-decoder")
+flags.DEFINE_string("problems", None, "see t2t-decoder")
+flags.DEFINE_string("hparams_set", "transformer_big_single_gpu", "see t2t-decoder")
+
+
+def main(_):
+  FLAGS = flags.FLAGS
+  tf.logging.set_verbosity(tf.logging.INFO)
+  model_dir = os.path.expanduser(FLAGS.model_dir)
+  translations_dir = os.path.expanduser(FLAGS.translations_dir)
+  source = os.path.expanduser(FLAGS.source)
+  os.makedirs(translations_dir, exist_ok=True)
+  translated_base_file = os.path.join(translations_dir, FLAGS.problems)
+
+  # Copy flags.txt with the original time, so t2t-bleu can report correct relative time.
+  flags_path = os.path.join(translations_dir, FLAGS.problems + '-flags.txt')
+  if not os.path.exists(flags_path):
+    shutil.copy2(os.path.join(model_dir, 'flags.txt'), flags_path)
+
+  for model in bleu_hook.stepfiles_iterator(model_dir, FLAGS.wait_minutes, FLAGS.min_steps):
+    tf.logging.info("Translating " + model.filename)
+    out_file = translated_base_file + '-' + str(model.steps)
+    if os.path.exists(out_file):
+      tf.logging.info(out_file + " already exists, so skipping it.")
+    else:
+      tf.logging.info("Translating " + out_file)
+      params = ("--t2t_usr_dir={FLAGS.t2t_usr_dir} --output_dir={model_dir} "
+         "--data_dir={FLAGS.data_dir} --problems={FLAGS.problems} "
+         "--decode_hparams=beam_size={FLAGS.beam_size},alpha={FLAGS.alpha} "
+         "--model={FLAGS.model} --hparams_set={FLAGS.hparams_set} "
+         "--checkpoint_path={model.filename} --decode_from_file={source} "
+         "--decode_to_file={out_file}".format(**locals()))
+      command = FLAGS.decoder_command.format(**locals())
+      tf.logging.info("Running:\n" + command)
+      os.system(command)
+
+if __name__ == "__main__":
+  tf.app.run()

--- a/tensor2tensor/utils/bleu_hook.py
+++ b/tensor2tensor/utils/bleu_hook.py
@@ -20,9 +20,12 @@ from __future__ import print_function
 
 import collections
 import math
+import os
 import re
 import sys
+import time
 import unicodedata
+from collections import namedtuple
 
 # Dependency imports
 
@@ -197,3 +200,68 @@ def bleu_wrapper(ref_filename, hyp_filename, case_sensitive=False):
   ref_tokens = [bleu_tokenize(x) for x in ref_lines]
   hyp_tokens = [bleu_tokenize(x) for x in hyp_lines]
   return compute_bleu(ref_tokens, hyp_tokens)
+
+
+StepFile = namedtuple('StepFile', 'filename mtime ctime steps')
+
+
+def _read_stepfiles_list(path_prefix, path_suffix='.index', min_steps=0):
+  stepfiles = []
+  for filename in tf.gfile.Glob(path_prefix + '*-[0-9]*' + path_suffix):
+    basename = filename[:-len(path_suffix)] if len(path_suffix) else filename
+    try:
+      steps = int(basename.rsplit('-')[-1])
+    except ValueError:  # The -[0-9]* part is not an integer.
+      continue
+    if steps < min_steps:
+      continue
+    if not os.path.exists(filename):
+      tf.logging.info(filename + " was deleted, so skipping it")
+      continue
+    stepfiles.append(StepFile(basename, os.path.getmtime(filename),
+                              os.path.getctime(filename), steps))
+  return sorted(stepfiles, key=lambda x: -x.steps)
+
+
+def stepfiles_iterator(path_prefix, wait_minutes=0, min_steps=0,
+                       path_suffix='.index', sleep_sec=10):
+  """Continuously yield new files with steps in filename as they appear.
+
+  This is useful for checkpoint files or other files whose names differ just in an interger
+  marking the number of steps and match the wildcard path_prefix + '*-[0-9]*' + path_suffix.
+  Unlike `tf.contrib.training.checkpoints_iterator`, this
+  implementation always starts from the oldest files
+  (and it cannot miss any file). Note that the oldest checkpoint
+  may be deleted anytime by Tensorflow (if set up so). It is up to the user
+  to check that the files returned by this generator actually exist.
+  Args:
+    path_prefix: The directory + possible common filename prefix to the files.
+    path_suffix: Common filename suffix (after steps), including possible extension dot.
+    wait_minutes: The maximum amount of minutes to wait between files.
+    min_steps: Skip files with lower global step.
+    sleep_sec: How often to check for new files.
+  Yields:
+    named tuples (filename, mtime, ctime, steps) of the files as they arrive.
+  """
+  # Wildcard D*-[0-9]* does not match D/x-1, so if D is a directory let path_prefix='D/'.
+  if not path_prefix.endswith(os.sep) and os.path.isdir(path_prefix):
+    path_prefix += os.sep
+  stepfiles = _read_stepfiles_list(path_prefix, path_suffix, min_steps)
+  tf.logging.info("Found %d files with steps: %s"
+                  % (len(stepfiles), ", ".join(str(x.steps) for x in reversed(stepfiles))))
+  exit_time = time.time() + wait_minutes * 60
+  while True:
+    if not stepfiles and wait_minutes:
+      tf.logging.info('Waiting till %s if a new file matching %s*-[0-9]*%s appears'
+                      % (time.asctime(time.localtime(exit_time)), path_prefix, path_suffix))
+      while True:
+        stepfiles = _read_stepfiles_list(path_prefix, path_suffix, min_steps)
+        if stepfiles or time.time() > exit_time:
+          break
+        time.sleep(sleep_sec)
+    if not stepfiles:
+      return
+
+    stepfile = stepfiles.pop()
+    exit_time, min_steps = stepfile.ctime + wait_minutes * 60, stepfile.steps + 1
+    yield stepfile


### PR DESCRIPTION
`t2t-bleu` computes the "real" BLEU
(giving the same result as [sacréBLEU](https://github.com/awslabs/sockeye/tree/master/contrib/sacrebleu) with `--tokenization intl`
and as [mteval-v14.pl](https://github.com/moses-smt/mosesdecoder/blob/master/scripts/generic/mteval-v14.pl) with `--international-tokenization`).
It can be used in two ways:
* To evaluate one translated file: `t2t-bleu --translation=my-wmt13.de --reference=wmt13_deen.de`
* To evaluate all translations in a given directory (created e.g. by `t2t-translate-all`).

`t2t-translate-all` translates all checkpoints in a given directory (created by `t2t-trainer` or `t2t-avg-all`).
A custom command (e.g. SGE cluster wrapper) can be used instead of `t2t-decoder` for the translation.

`t2t-avg-all` for each checkpoint in a given directory
it averages it with the N preceding ones.

All three scripts wait a given number of minutes for new checkpoints
(produced by t2t-decoder, which can be run concurrently with these scripts).

This PR is an improved version of #436 (which was not fully merged).
