### PR TITLE
Show t2t-bleu usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,12 @@ t2t-decoder \
   --hparams_set=$HPARAMS \
   --output_dir=$TRAIN_DIR \
   --decode_hparams="beam_size=$BEAM_SIZE,alpha=$ALPHA" \
-  --decode_from_file=$DECODE_FILE
+  --decode_from_file=$DECODE_FILE \
+  --decode_to_file=translation.en
 
-cat $DECODE_FILE.$MODEL.$HPARAMS.beam$BEAM_SIZE.alpha$ALPHA.decodes
+# Eval BLEU
+# (Always report proper BLEU in papers, not the internal approx_bleu.)
+t2t-bleu --translation=translation.en --reference=ref-translation.de
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ t2t-trainer \
 DECODE_FILE=$DATA_DIR/decode_this.txt
 echo "Hello world" >> $DECODE_FILE
 echo "Goodbye world" >> $DECODE_FILE
+echo -e 'Hallo Welt\nAuf Wiedersehen Welt' > ref-translation.de
 
 BEAM_SIZE=4
 ALPHA=0.6


### PR DESCRIPTION
Many researchers are still reporting approx_bleu and comparing it with proper BLEU reported in other papers.
We should guide them to not do this and minimize the risk of false-news papers, such as https://arxiv.org/abs/1712.09662.