### PR TITLE
Fixing import error / broken notebook, see #548.  Plus bumping up 1.5.0rc0 -> 1.5.0

### DIFF
--- a/tensor2tensor/notebooks/hello_t2t.ipynb
+++ b/tensor2tensor/notebooks/hello_t2t.ipynb
@@ -60,8 +60,8 @@
       },
       "source": [
         "# Install deps\n",
-        "# We're using some new features from tensorflow so we install 1.5.0rc0\n",
-        "!pip install -q 'tensor2tensor==1.4.1' 'tensorflow==1.5.0rc0'"
+        "# We're using some new features from tensorflow so we install 1.5.0\n",
+        "!pip install -q 'tensor2tensor==1.4.1' 'tensorflow==1.5.0' 'gym=0.9.2'"
       ],
       "cell_type": "code",
       "execution_count": 0,


### PR DESCRIPTION
This addresses #548.  

Steps to reproduce #548 , in the notebook:
  !pip install -q 'tensor2tensor==1.4.1' 'tensorflow==1.5.0rc0'
  from tensor2tensor import problems
Produces:
ImportErrorTraceback (most recent call last)
      7 from tensor2tensor import models
----> 8 from tensor2tensor import problems

See also openai/gym#838 and #520

