### PR TITLE
Move save_metadata function to after exp_fn is created

### DIFF
--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -328,12 +328,12 @@ def main(argv):
   if argv:
     set_hparams_from_args(argv[1:])
   hparams = create_hparams()
-  if is_chief():
-    save_metadata(hparams)
 
   with maybe_cloud_tpu():
     exp_fn = create_experiment_fn()
     exp = exp_fn(create_run_config(hparams), hparams)
+    if is_chief():
+      save_metadata(hparams)
     execute_schedule(exp)
 
 


### PR DESCRIPTION
Allows the `hparams.json` file to include hparams added by the problems.