### PR TITLE
enmk: fix dataset generation

### DIFF
--- a/tensor2tensor/data_generators/translate_enmk.py
+++ b/tensor2tensor/data_generators/translate_enmk.py
@@ -63,7 +63,4 @@ class TranslateEnmkSetimes32k(translate.TranslateProblem):
 
   def source_data_files(self, dataset_split):
     train = dataset_split == problem.DatasetSplit.TRAIN
-    datasets = _MKEN_TRAIN_DATASETS if train else _MKEN_TEST_DATASETS
-    source_datasets = [[item[0], [item[1][0]]] for item in datasets]
-    target_datasets = [[item[0], [item[1][1]]] for item in datasets]
-    return source_datasets + target_datasets
+    return _MKEN_TRAIN_DATASETS if train else _MKEN_TEST_DATASETS


### PR DESCRIPTION
Hi,

*1.5.2* introduces some modifications in the `compile_data` function of the `translate` data generator. The `TranslateEnmkSetimes32k` problem uses a customized `source_data_files` function which was no longer compatible to the changes introduces in *1.5.2*. The leads to the following error:

```bash
  File "/mnt/tensor2tensor/tensor2tensor/data_generators/translate.py", line 243, in compile_data                                                                       
    lang1_filename, lang2_filename = dataset[1]                                     
ValueError: not enough values to unpack (expected 2, got 1) 
```

This PR fixes this problem :)