### PR TITLE
Makes approx_vocab_size a property as was intended

### DIFF
--- a/tensor2tensor/data_generators/text_problems.py
+++ b/tensor2tensor/data_generators/text_problems.py
@@ -127,6 +127,7 @@ class Text2TextProblem(problem.Problem):
     """
     return VocabType.SUBWORD
 
+  @property
   def approx_vocab_size(self):
     """Approximate vocab size to generate. Only for VocabType.SUBWORD."""
     return 2**15  # ~32k


### PR DESCRIPTION
approx_vocab_size is treated as a property later on in the file in, for example, vocab_filename.