### PR TITLE
fix: avoid tokenizer error on too big unicode point

### DIFF
--- a/tensor2tensor/data_generators/text_encoder.py
+++ b/tensor2tensor/data_generators/text_encoder.py
@@ -379,7 +379,7 @@ def _unescape_token(escaped_token):
     try:
       return six.unichr(int(m.group(1)))
     except (ValueError, OverflowError) as _:
-      return ""
+      return u"\u3013"
 
   trimmed = escaped_token[:-1] if escaped_token.endswith("_") else escaped_token
   return _UNESCAPE_REGEX.sub(match, trimmed)


### PR DESCRIPTION
If vocab.decode() make too big unicode point like "\u9876543;",  match() returns null string and tokenizer.decoder() raises "string index out of range" when accessing the first character of the null string.

This fix returns "\u3013" (used generally as undefined character) in such case.