### PR TITLE
Makes approx_vocab_size a property

### DIFF
--- a/tensor2tensor/data_generators/translate.py
+++ b/tensor2tensor/data_generators/translate.py
@@ -39,6 +39,7 @@ class TranslateProblem(text_problems.Text2TextProblem):
   def is_generate_per_split(self):
     return True
 
+  @property
   def approx_vocab_size(self):
     return 2**15
 


### PR DESCRIPTION
One more approx_vocab_size that should be decorated with @property. All the rest of the
instances of approx_vocab_size have this decoration.