### PR TITLE
fix txt_line_iterator to not stop at empty line

### DIFF
--- a/tensor2tensor/data_generators/text_problems.py
+++ b/tensor2tensor/data_generators/text_problems.py
@@ -418,9 +418,9 @@ class Text2ClassProblem(Text2TextProblem):
 def txt_line_iterator(txt_path):
   """Iterate through lines of file."""
   with tf.gfile.Open(txt_path) as f:
-    readline = lambda: f.readline().strip()
+    readline = lambda: f.readline()
     for line in iter(readline, ""):
-      yield line
+      yield line.strip()
 
 
 def text2text_txt_iterator(source_txt_path, target_txt_path):


### PR DESCRIPTION
In the text problem re-factor commit [`765d33`](https://github.com/tensorflow/tensor2tensor/commit/765d33bb6890cc7b8f194257d9c71226c26e0162) the behavior of the text iterator was changed in a way that it stops on the first empty line.

This breaks the ende translation, since the parallel corpus contains quite some empty lines and therefore was stopping after 235 lines of `news-commentary-v12.de-en.en`.

Here is a fix, which `strip()`'s only when yielding the result as it was in version `1.5.1`.