### PR TITLE
Fix PTB data generator.

### DIFF
--- a/tensor2tensor/data_generators/ptb.py
+++ b/tensor2tensor/data_generators/ptb.py
@@ -77,6 +77,37 @@ def _get_token_encoder(vocab_dir, vocab_name, filename):
   return text_encoder.TokenTextEncoder(vocab_path)
 
 
+def _maybe_download_corpus(tmp_dir, vocab_type):
+  """Download and unpack the corpus.
+
+  Args:
+    tmp_dir: directory containing dataset.
+  """
+  filename = os.path.basename(PTB_URL)
+  compressed_filepath = generator_utils.maybe_download(
+      tmp_dir, filename, PTB_URL)
+  ptb_files = []
+  ptb_char_files = []
+
+  with tarfile.open(compressed_filepath, "r:gz") as tgz:
+    files = []
+    # Selecting only relevant files.
+    for m in tgz.getmembers():
+      if "ptb" in m.name and ".txt" in m.name:
+        if "char" in m.name:
+          ptb_char_files += [m.name]
+        else:
+          ptb_files += [m.name]
+        files += [m]
+
+    tgz.extractall(tmp_dir, members=files)
+
+  if vocab_type == text_problems.VocabType.CHARACTER:
+    return ptb_char_files
+  else:
+    return ptb_files
+
+
 @registry.register_problem
 class LanguagemodelPtb10k(text_problems.Text2SelfProblem):
   """PTB, 10k vocab."""
@@ -92,6 +123,10 @@ class LanguagemodelPtb10k(text_problems.Text2SelfProblem):
     }]
 
   @property
+  def is_generate_per_split(self):
+    return True
+
+  @property
   def vocab_filename(self):
     return "vocab.lmptb.10000"
 
@@ -100,28 +135,7 @@ class LanguagemodelPtb10k(text_problems.Text2SelfProblem):
     return text_problems.VocabType.TOKEN
 
   def generate_samples(self, data_dir, tmp_dir, dataset_split):
-    filename = os.path.basename(PTB_URL)
-    compressed_filepath = generator_utils.maybe_download(
-        tmp_dir, filename, PTB_URL)
-    ptb_files = []
-    ptb_char_files = []
-    with tarfile.open(compressed_filepath, "r:gz") as tgz:
-      files = []
-      # Selecting only relevant files.
-      for m in tgz.getmembers():
-        if "ptb" in m.name and ".txt" in m.name:
-          if "char" in m.name:
-            ptb_char_files += [m.name]
-          else:
-            ptb_files += [m.name]
-          files += [m]
-
-      tgz.extractall(tmp_dir, members=files)
-
-    if self.vocab_type == text_problems.VocabType.CHARACTER:
-      files = ptb_char_files
-    else:
-      files = ptb_files
+    files = _maybe_download_corpus(tmp_dir, self.vocab_type)
 
     train_file, valid_file = None, None
     for filename in files:
@@ -138,10 +152,13 @@ class LanguagemodelPtb10k(text_problems.Text2SelfProblem):
     train = dataset_split == problem.DatasetSplit.TRAIN
     filepath = train_file if train else valid_file
 
-    with tf.gfile.GFile(filepath, "r") as f:
-      for line in f:
-        line = " ".join(line.replace("\n", " %s " % EOS).split())
-        yield {"targets": line}
+    def _generate_samples():
+      with tf.gfile.GFile(filepath, "r") as f:
+        for line in f:
+          line = " ".join(line.replace("\n", " %s " % EOS).split())
+          yield {"targets": line}
+
+    return _generate_samples()
 
 
 @registry.register_problem


### PR DESCRIPTION
Fixes PTB data generator, which seemed to get overlooked in a recent refactor.

* Adds `is_generate_per_split` property.
* Downloads corpus before returning generator in generate_samples. This is because `Text2TextProblem`'s `generate_encoded_samples` method expects a generator to be returned from `generate_samples`, but for `TOKEN` vocabularies the file must already exist before `get_or_create_vocab` is called (https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/data_generators/text_problems.py#L222).
* Moves code to download corpus out of generate_samples method (seemed a bit clearer).