### PR TITLE
en-mk: add new character-based problem

### DIFF
--- a/tensor2tensor/data_generators/translate_enmk.py
+++ b/tensor2tensor/data_generators/translate_enmk.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 
 from tensor2tensor.data_generators import problem
 from tensor2tensor.data_generators import text_encoder
+from tensor2tensor.data_generators import text_problems
 from tensor2tensor.data_generators import translate
 from tensor2tensor.utils import registry
 
@@ -60,6 +61,18 @@ class TranslateEnmkSetimes32k(translate.TranslateProblem):
   @property
   def vocab_filename(self):
     return "vocab.enmk.%d" % self.approx_vocab_size
+
+  def source_data_files(self, dataset_split):
+    train = dataset_split == problem.DatasetSplit.TRAIN
+    return _ENMK_TRAIN_DATASETS if train else _ENMK_TEST_DATASETS
+
+@registry.register_problem
+class TranslateEnmkSetimesCharacters(translate.TranslateProblem):
+  """Problem spec for SETimes En-Mk translation."""
+
+  @property
+  def vocab_type(self):
+    return text_problems.VocabType.CHARACTER
 
   def source_data_files(self, dataset_split):
     train = dataset_split == problem.DatasetSplit.TRAIN


### PR DESCRIPTION
Hi,

this PR adds the possibility for char-based NMT for English-Macedonian: `TranslateEnmkSetimesCharacters`.

BLEU-score for experiments I did with different `tensor2tensor` versions (all on DGX-1):

| Experiment | BLEU-score
| -------------- | ----------------
| Transformer (1.1.0) | 52,70
| Transformer - character-based (1.1.0) | 34,26
| Transformer (1.5.2) | 54,00 (uncased)
| Transformer - character-based (1.5.2) | 37.43 (uncased)

