### PR TITLE
WIP: github: add initial issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- **Note** Please tag your issue with *bug*, *feature request* or *help* -->
+
+### Description
+
+> …
+
+### *TensorFlow* and *tensor2tensor* versions
+
+<!-- **Note** Run `pip list | grep tensor` to include TensorFlow and tensor2tensor versions -->
+
+> …
+
+### In case of bug report: Steps to reproduce the problem
+
+> …
+
+### In case of bug report: Error log
+
+<!-- Please use code markdown to format output messages. -->
+<!-- See https://help.github.com/articles/creating-and-highlighting-code-blocks/ -->
+
+> …


### PR DESCRIPTION
Hi,

this PR introduce an issue template for GitHub.

In the "write" mode of an issue, various useful hints are shown:

![issue_template_write](https://user-images.githubusercontent.com/20651387/36928845-dc3c8b4c-1e89-11e8-9b0c-6e4182e19e4e.png)

I merged this PR into my forked repository, so you can play around with the issue template. See it [here](https://github.com/stefan-it/tensor2tensor/issues/new).

Please let me know if we need to include more information :)
