### PR TITLE
Fix the language model predition shape error.

### DIFF
--- a/tensor2tensor/models/transformer.py
+++ b/tensor2tensor/models/transformer.py
@@ -296,7 +296,10 @@ class Transformer(t2t_model.T2TModel):
       # We force the outputs to begin with these sequences.
       encoder_output = None
       encoder_decoder_attention_bias = None
-      partial_targets = tf.squeeze(tf.to_int64(features["inputs"]), [2, 3])
+      if len(features["inputs"].shape) >= 4:
+        partial_targets = tf.squeeze(tf.to_int64(features["inputs"]), [2, 3])
+      else:
+        partial_targets = tf.squeeze(tf.to_int64(features["inputs"]), [2])
       partial_targets_length = common_layers.shape_list(partial_targets)[1]
       decode_length += partial_targets_length
       batch_size = tf.shape(partial_targets)[0]


### PR DESCRIPTION
This pull request is to fix the issue "https://github.com/tensorflow/tensor2tensor/issues/649" .
When the transformer is trained as a language model, the input is set to partial_targets. But the shape doesn't contain the fourth dimension.
After testing with my own dataset, the problem is fixed by this modified code.