### PR TITLE
Fixed small issues with ML Engine script.

### DIFF
--- a/docs/cloud_mlengine.md
+++ b/docs/cloud_mlengine.md
@@ -28,8 +28,12 @@ machines with 4 or 8 GPUs.
 You can additionally pass the `--cloud_mlengine_master_type` to select another
 kind of machine (see the [docs for
 `masterType`](https://cloud.google.com/ml-engine/reference/rest/v1/projects.jobs#traininginput)
-for your options). If you provide this flag yourself, make sure you pass the
-correct value for `--worker_gpu`.
+for options, including 
+[ML Engine machine types](https://cloud.google.com/ml-engine/docs/training-overview)
+and their
+[specs](https://cloud.google.com/compute/docs/machine-types)).
+If you provide this flag yourself, make sure you pass the
+correct value for `--worker_gpu` (for non-GPU machines, you must explicitly pass `--worker_gpu=0`).
 
 **Note**: `t2t-trainer` only currently supports launching with single machines,
 possibly with multiple GPUs. Multi-machine setups are not yet supported out of

--- a/tensor2tensor/utils/cloud_mlengine.py
+++ b/tensor2tensor/utils/cloud_mlengine.py
@@ -275,13 +275,13 @@ def validate_flags():
       assert FLAGS.cloud_mlengine_master_type == 'standard_tpu'
     elif FLAGS.worker_gpu:
       if FLAGS.worker_gpu == 1:
-        assert FLAGS.cloud_ml_engine_master_type in ['standard_gpu',
+        assert FLAGS.cloud_mlengine_master_type in ['standard_gpu',
                                                      'standard_p100']
       elif FLAGS.worker_gpu == 4:
-        assert FLAGS.cloud_ml_engine_master_type in ['complex_model_m_gpu',
+        assert FLAGS.cloud_mlengine_master_type in ['complex_model_m_gpu',
                                                      'complex_model_m_p100']
       else:
-        assert FLAGS.cloud_ml_engine_master_type == 'complex_model_l_gpu'
+        assert FLAGS.cloud_mlengine_master_type == 'complex_model_l_gpu'
     else:
       assert FLAGS.cloud_mlengine_master_type in ['standard', 'large_model',
                                                   'complex_model_s',

--- a/tensor2tensor/utils/cloud_mlengine.py
+++ b/tensor2tensor/utils/cloud_mlengine.py
@@ -140,7 +140,8 @@ def launch_job(job_spec):
   """Launch job on ML Engine."""
   project_id = 'projects/{}'.format(cloud.default_project())
   credentials = GoogleCredentials.get_application_default()
-  cloudml = discovery.build('ml', 'v1', credentials=credentials)
+  cloudml = discovery.build(
+    'ml', 'v1', credentials=credentials, cache_discovery=False)
   request = cloudml.projects().jobs().create(body=job_spec, parent=project_id)
   request.execute()
 

--- a/tensor2tensor/utils/cloud_mlengine.py
+++ b/tensor2tensor/utils/cloud_mlengine.py
@@ -276,10 +276,10 @@ def validate_flags():
     elif FLAGS.worker_gpu:
       if FLAGS.worker_gpu == 1:
         assert FLAGS.cloud_mlengine_master_type in ['standard_gpu',
-                                                     'standard_p100']
+                                                    'standard_p100']
       elif FLAGS.worker_gpu == 4:
         assert FLAGS.cloud_mlengine_master_type in ['complex_model_m_gpu',
-                                                     'complex_model_m_p100']
+                                                    'complex_model_m_p100']
       else:
         assert FLAGS.cloud_mlengine_master_type == 'complex_model_l_gpu'
     else:


### PR DESCRIPTION
This fixes the following issues:

- A typo in FLAGS which was looking for `cloud_ml_engine_master_type` rather than `cloud_mlengine_master_type`. 
- An error being raised based on API client dependency versions (see https://github.com/google/google-api-python-client/issues/299)
- Some clarification in the docs when using non-GPU workers.