### PR TITLE
Fix transformer decoding when using attention other than dot_product.

### DIFF
--- a/tensor2tensor/models/transformer.py
+++ b/tensor2tensor/models/transformer.py
@@ -225,6 +225,13 @@ class Transformer(t2t_model.T2TModel):
               None if using greedy decoding (beam_size=1)
       }
     """
+    if self._hparams.self_attention_type != "dot_product":
+      # Caching is not guaranteed to work with attention types other than
+      # dot_product.
+      # TODO(petershaw): Support fast decoding when using relative
+      # position representations, i.e. "dot_product_relative" attention.
+      return self._beam_decode_slow(features, decode_length, beam_size,
+                                    top_beams, alpha)
     with tf.variable_scope(self.name):
       return self._fast_decode(
           features, decode_length, beam_size, top_beams, alpha)


### PR DESCRIPTION
Note that _beam_decode_slow should not be wrapped in variable_scope(name)
unlike _fast_decode which must be wrapped so.
Fixes #674 and allows to decode with transformer_relative.
This PR is an substitute for #675 (same, but rebased on v1.5.5).