### PR TITLE
Fix two bugs : 1. Add decode_list in ClassLabelEncoder, 2. Fix the bug for language model problem's beam search

### DIFF
--- a/tensor2tensor/data_generators/text_encoder.py
+++ b/tensor2tensor/data_generators/text_encoder.py
@@ -208,9 +208,11 @@ class ClassLabelEncoder(TextEncoder):
 
   def decode(self, label_id):
     if isinstance(label_id, list):
-      assert len(label_id) == 1
-      label_id, = label_id
+      return self._class_labels[label_id[0]]
     return self._class_labels[label_id]
+
+  def decode_list(self, ids):
+    return [self._class_labels[i] for i in ids]
 
   @property
   def vocab_size(self):

--- a/tensor2tensor/models/transformer.py
+++ b/tensor2tensor/models/transformer.py
@@ -457,8 +457,6 @@ def fast_decode(encoder_output,
     cache["encoder_output"] = encoder_output
     cache["encoder_decoder_attention_bias"] = encoder_decoder_attention_bias
 
-  logits = None
-
   if beam_size > 1:  # Beam Search
     initial_ids = tf.zeros([batch_size], dtype=tf.int32)
     decoded_ids, scores = beam_search.beam_search(
@@ -495,7 +493,7 @@ def fast_decode(encoder_output,
     decoded_ids = tf.zeros([batch_size, 0], dtype=tf.int64)
     finished = tf.fill([batch_size], False)
     next_id = tf.zeros([batch_size, 1], dtype=tf.int64)
-    _, _, _, decoded_ids, _,logits = tf.while_loop(
+    _, _, _, decoded_ids, _ = tf.while_loop(
         is_not_finished,
         inner_loop,
         [tf.constant(0), finished, next_id, decoded_ids, cache],
@@ -508,7 +506,7 @@ def fast_decode(encoder_output,
         ])
     scores = None
 
-  return {"outputs": decoded_ids, "scores": scores,"logits":logits}
+  return {"outputs": decoded_ids, "scores": scores}
 
 
 @registry.register_model


### PR DESCRIPTION
1. For the ClassLabelEncoder, it's derived from TextEncoder and didn't implement decode_list, so it didn't not produce correct labels when passing a list of class ids.
2. For transformer, if the problem is a language model, it didn't return the correct beam size when doing the beam search. This fix will ensure the beam search produce the correct the search results for problems with no "input", a.k.a language model.
 