### PR TITLE
To fix the BLEU Evaluation Error #706

### DIFF
--- a/tensor2tensor/utils/bleu_hook.py
+++ b/tensor2tensor/utils/bleu_hook.py
@@ -25,6 +25,8 @@ import re
 import sys
 import time
 import unicodedata
+#To fix issue:#706
+import io
 
 # Dependency imports
 
@@ -39,7 +41,7 @@ import tensorflow as tf
 
 
 def _get_ngrams(segment, max_order):
-  """Extracts all n-grams up to a given maximum order from an input segment.
+  """Extracts all n-grams upto a given maximum order from an input segment.
 
   Args:
     segment: text segment from which n-grams will be extracted.
@@ -130,7 +132,7 @@ def bleu_score(predictions, labels, **unused_kwargs):
   and use brevity penalty. Also, this does not have beam search.
 
   Args:
-    predictions: tensor, model predictions
+    predictions: tensor, model predicitons
     labels: tensor, gold output.
 
   Returns:
@@ -194,8 +196,9 @@ def bleu_tokenize(string):
 
 def bleu_wrapper(ref_filename, hyp_filename, case_sensitive=False):
   """Compute BLEU for two files (reference and hypothesis translation)."""
-  ref_lines = open(ref_filename).read().splitlines()
-  hyp_lines = open(hyp_filename).read().splitlines()
+  #To fix the issue #706
+  ref_lines = io.open(ref_filename, 'rt', encoding='utf-8').read().splitlines()
+  hyp_lines = io.open(hyp_filename, 'rt', encoding='utf-8').read().splitlines()
   assert len(ref_lines) == len(hyp_lines)
   if not case_sensitive:
     ref_lines = [x.lower() for x in ref_lines]

--- a/tensor2tensor/utils/bleu_hook.py
+++ b/tensor2tensor/utils/bleu_hook.py
@@ -41,7 +41,7 @@ import tensorflow as tf
 
 
 def _get_ngrams(segment, max_order):
-  """Extracts all n-grams upto a given maximum order from an input segment.
+  """Extracts all n-grams up to a given maximum order from an input segment.
 
   Args:
     segment: text segment from which n-grams will be extracted.
@@ -132,7 +132,7 @@ def bleu_score(predictions, labels, **unused_kwargs):
   and use brevity penalty. Also, this does not have beam search.
 
   Args:
-    predictions: tensor, model predicitons
+    predictions: tensor, model predictions
     labels: tensor, gold output.
 
   Returns:


### PR DESCRIPTION
The evaluation using t2t-bleu failing using Python 3.5.4. The issue is due to deletion of the "encoding='utf-8'" tag in the previous version of `bleu_hook.py' file for support Python2. Please refer to bug #706 for details.