### PR TITLE
Decode bytes into string when getting cloud 

### DIFF
--- a/tensor2tensor/utils/cloud_mlengine.py
+++ b/tensor2tensor/utils/cloud_mlengine.py
@@ -111,7 +111,7 @@ def configure_job():
   training_input = {
       'pythonModule': 'tensor2tensor.bin.t2t_trainer',
       'args': flags_as_args(),
-      'region': cloud.default_region(),
+      'region': cloud.default_region().decode('utf-8'),
       'runtimeVersion': '1.5',
       'pythonVersion': '3.5' if sys.version_info.major == 3 else '2.7',
       'jobDir': FLAGS.output_dir,
@@ -138,7 +138,7 @@ def configure_job():
 
 def launch_job(job_spec):
   """Launch job on ML Engine."""
-  project_id = 'projects/{}'.format(cloud.default_project())
+  project_id = 'projects/{}'.format(cloud.default_project().decode('utf-8'))
   credentials = GoogleCredentials.get_application_default()
   cloudml = discovery.build('ml', 'v1', credentials=credentials,
                             cache_discovery=False)
@@ -171,7 +171,7 @@ def tar_and_copy_t2t(train_dir):
   """Tar Tensor2Tensor and cp to train_dir."""
   tf.logging.info('Tarring and pushing local Tensor2Tensor package.')
 
-  output = cloud.shell_output('pip show tensor2tensor').split('\n')
+  output = cloud.shell_output('pip show tensor2tensor').decode('utf-8').split('\n')
   assert output[1].startswith('Version')
   assert output[7].startswith('Location')
   t2t_version = output[1].split(':')[1].strip()


### PR DESCRIPTION
The tensor2tensor.utils.cloud_tpu (or cloud in this file) library's methods typically return byte strings and not strings, however cloud_mlengine.py mostly treats the results as strings.

An alternative change might be to use decode here instead: https://github.com/tensorflow/tensor2tensor/blob/120315cbe35f468876512b790dc77d792d4db72c/tensor2tensor/utils/cloud_tpu.py#L219 (Note that check_output returns a byte string: https://docs.python.org/2/library/subprocess.html)

Example error when attempting to run t2t-trainer:
TypeError: b'' is not JSON serializable