### PR TITLE
Minor pylint fixes

### DIFF
--- a/tensor2tensor/__init__.py
+++ b/tensor2tensor/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tensor2tensor/bin/__init__.py
+++ b/tensor2tensor/bin/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tensor2tensor/data_generators/__init__.py
+++ b/tensor2tensor/data_generators/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tensor2tensor/insights/__init__.py
+++ b/tensor2tensor/insights/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tensor2tensor/layers/__init__.py
+++ b/tensor2tensor/layers/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tensor2tensor/layers/common_attention.py
+++ b/tensor2tensor/layers/common_attention.py
@@ -27,7 +27,6 @@ import operator
 import numpy as np
 
 from six.moves import range  # pylint: disable=redefined-builtin
-from six.moves import range  # pylint: disable=redefined-builtin
 from six.moves import zip  # pylint: disable=redefined-builtin
 
 from tensor2tensor.layers import common_layers

--- a/tensor2tensor/models/research/__init__.py
+++ b/tensor2tensor/models/research/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tensor2tensor/models/research/lm_experiments.py
+++ b/tensor2tensor/models/research/lm_experiments.py
@@ -98,4 +98,3 @@ def lmx_h4k_f16k():
   hparams.batch_size = 1024
   hparams.weight_dtype = "bfloat16"
   return hparams
-

--- a/tensor2tensor/rl/__init__.py
+++ b/tensor2tensor/rl/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tensor2tensor/rl/envs/__init__.py
+++ b/tensor2tensor/rl/envs/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tensor2tensor/serving/__init__.py
+++ b/tensor2tensor/serving/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tensor2tensor/utils/__init__.py
+++ b/tensor2tensor/utils/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tensor2tensor/visualization/__init__.py
+++ b/tensor2tensor/visualization/__init__.py
@@ -12,5 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-


### PR DESCRIPTION
Hi,

this PR applies some fixes recommended by `pylint`: 

* [W0404 (Used when a module is reimported multiple times)](https://github.com/PyCQA/pylint/blob/df1abe8d275970dbaefd2ccc4c22ad1c83eb381c/pylint/checkers/imports.py#L214)

* [C0305 (Used when there are trailing blank lines in a file)](https://github.com/PyCQA/pylint/blob/7fea701175aeefb0ab6f8613501f739a91671b3a/pylint/checkers/format.py#L93)