### PR TITLE
Fix bug if top_beams > 1

### DIFF
--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -665,7 +665,7 @@ class T2TModel(base.Layer):
     if top_beams == 1:
       samples = ids[:, 0, 1:]
     else:
-      samples = ids[:, :top_beams, 1]
+      samples = ids[:, :top_beams, 1:]
 
     return {"outputs": samples, "scores": scores}
 


### PR DESCRIPTION
If top_beams > 1 (return_beams=True) only the first word of every beam was returned. Bug introduced with last change of this line.