### PR TITLE
A hacky way of fixing value function computation.

### DIFF
--- a/tensor2tensor/rl/collect.py
+++ b/tensor2tensor/rl/collect.py
@@ -22,9 +22,10 @@ import tensorflow as tf
 
 def define_collect(policy_factory, batch_env, hparams,
                    eval_phase, policy_to_actions_lambda=None,
-                   scope="", preprocess=None):
+                   scope="", preprocess=None, on_simulated=False):
   """Collect trajectories."""
   eval_phase = tf.convert_to_tensor(eval_phase)
+  on_simulated = tf.convert_to_tensor(on_simulated)
   batch_env_shape = batch_env.observ.get_shape().as_list()
   if preprocess is not None:
     batch_env_shape = preprocess[1]
@@ -51,7 +52,8 @@ def define_collect(policy_factory, batch_env, hparams,
     return tf.group(batch_env.reset(tf.range(len(batch_env))),
                     tf.assign(cumulative_rewards, tf.zeros(len(batch_env))))
   reset_op = tf.cond(
-      tf.logical_or(should_reset_var, eval_phase), group, tf.no_op)
+      tf.logical_or(should_reset_var, tf.logical_or(eval_phase, on_simulated)),
+      group, tf.no_op)
 
   with tf.control_dependencies([reset_op]):
     reset_once_op = tf.assign(should_reset_var, False)

--- a/tensor2tensor/rl/model_rl_experiment.py
+++ b/tensor2tensor/rl/model_rl_experiment.py
@@ -146,12 +146,13 @@ def train_agent(problem_name, simulated_problem_name, agent_model_dir,
   ppo_hparams.simulated_environment = True
   ppo_hparams.simulation_random_starts = hparams.simulation_random_starts
   ppo_hparams.intrinsic_reward_scale = hparams.intrinsic_reward_scale
-  ppo_hparams.eval_every_epochs = 0
+  ppo_hparams.eval_every_epochs = 10
   ppo_hparams.save_models_every_epochs = ppo_epochs_num
   ppo_hparams.epoch_length = hparams.ppo_epoch_length
   ppo_hparams.num_agents = hparams.ppo_num_agents
   ppo_hparams.problem = gym_problem
   ppo_hparams.world_model_dir = world_model_dir
+  hparams.ppo_time_limit = max(ppo_hparams.epoch_length*4 + 20, 1000)
 
   in_graph_wrappers = [
       (TimeLimitWrapper, {"timelimit": hparams.ppo_time_limit}),
@@ -451,11 +452,11 @@ def rl_modelrl_base():
       # Our simulated envs do not know how to reset.
       # You should set ppo_time_limit to the value you believe that
       # the simulated env produces a reasonable output.
-      ppo_time_limit=200,
+      ppo_time_limit=200,  # TODO(blazej) - currently it is unused.
       # It makes sense to have ppo_time_limit=ppo_epoch_length,
       # though it is not necessary.
-      ppo_epoch_length=200,
-      ppo_num_agents=8,
+      ppo_epoch_length=40,
+      ppo_num_agents=20,
       # Whether the PPO agent should be restored from the previous iteration, or
       # should start fresh each time.
       ppo_continue_training=True,

--- a/tensor2tensor/rl/rl_trainer_lib.py
+++ b/tensor2tensor/rl/rl_trainer_lib.py
@@ -58,7 +58,8 @@ def define_train(hparams, environment_spec, event_dir):
 
   with tf.variable_scope(tf.get_variable_scope(), reuse=tf.AUTO_REUSE):
     memory, collect_summary = collect.define_collect(
-        policy_factory, batch_env, hparams, eval_phase=False)
+        policy_factory, batch_env, hparams, eval_phase=False,
+        on_simulated=hparams.simulated_environment)
     ppo_summary = ppo.define_ppo_epoch(memory, policy_factory, hparams)
     summary = tf.summary.merge([collect_summary, ppo_summary])
 
@@ -77,7 +78,7 @@ def define_train(hparams, environment_spec, event_dir):
         num_agents=hparams.num_eval_agents, xvfb=hparams.video_during_eval)
 
     # TODO(blazej0): correct to the version below.
-    corrected = False
+    corrected = True
     eval_summary = tf.no_op()
     if corrected:
       _, eval_summary = collect.define_collect(


### PR DESCRIPTION
For now:
* ppo_time_limit hparameter is unused
* ppo_epoch_length * 4 is the biggest number of steps in the simulated
enviroment during PPO. Thus this value should be set reasonably (and
not large). Batch size can be compensated by increasing ppo_num_agents.