### PR TITLE
Wrap constant learning rate as Tensor

### DIFF
--- a/tensor2tensor/utils/learning_rate.py
+++ b/tensor2tensor/utils/learning_rate.py
@@ -44,17 +44,10 @@ def learning_rate_schedule(hparams):
   schedule_string = hparams.learning_rate_schedule
   names = schedule_string.split("*")
   names = [name.strip() for name in names if name.strip()]
-  lr_value = 1.0
+  ret = tf.constant(1.0)
   for name in names:
-    lr_value *= learning_rate_factor(name, step_num, hparams)
-
-  with tf.variable_scope("training"):
-    lr = tf.get_variable("learning_rate", [], trainable=False)
-    update_ops = tf.get_collection_ref(tf.GraphKeys.UPDATE_OPS)
-    assign_lr = tf.assign(lr, lr_value)
-    update_ops.append(assign_lr)
-
-  return lr
+    ret *= learning_rate_factor(name, step_num, hparams)
+  return ret
 
 
 def legacy_learning_rate_schedule(hparams):

--- a/tensor2tensor/utils/learning_rate.py
+++ b/tensor2tensor/utils/learning_rate.py
@@ -44,10 +44,17 @@ def learning_rate_schedule(hparams):
   schedule_string = hparams.learning_rate_schedule
   names = schedule_string.split("*")
   names = [name.strip() for name in names if name.strip()]
-  ret = 1.0
+  lr_value = 1.0
   for name in names:
-    ret *= learning_rate_factor(name, step_num, hparams)
-  return ret
+    lr_value *= learning_rate_factor(name, step_num, hparams)
+
+  with tf.variable_scope("training"):
+    lr = tf.get_variable("learning_rate", [], trainable=False)
+    update_ops = tf.get_collection_ref(tf.GraphKeys.UPDATE_OPS)
+    assign_lr = tf.assign(lr, lr_value)
+    update_ops.append(assign_lr)
+
+  return lr
 
 
 def legacy_learning_rate_schedule(hparams):


### PR DESCRIPTION
When training with ```learning_rate_schedule=constant```, ```learning_rate``` is float type and would be wrapped as TF Variable by TensorFlow at [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/layers/python/layers/optimizers.py#L179), thus to be saved at checkpoint. However, when training with ```learning_rate_schedule= rsqrt_decay``` and other schedule mechanism(non-constant), ```learning_rate``` would be normal Tensor rather than Variable, and will not be saved at checkpoint, that leads error like #809 .
As it's not necessary to save ```learning_rate``` at checkpoint file, we can restore it from ```global_step``` and learning rate schedule which are set by hparams.
This PR wrap ```learning_rate``` as Tensor for both constant and non-constant values, then TF will not save it in checkpoint file. If we load a pre-trained model, it doesn't complains errors like  #809 . I have tested this fix offline and it works well.