### PR TITLE
Add English-Indonesian

### DIFF
--- a/tensor2tensor/data_generators/all_problems.py
+++ b/tensor2tensor/data_generators/all_problems.py
@@ -53,6 +53,7 @@ modules = [
     "tensor2tensor.data_generators.translate_ende",
     "tensor2tensor.data_generators.translate_enet",
     "tensor2tensor.data_generators.translate_enfr",
+    "tensor2tensor.data_generators.translate_enid",
     "tensor2tensor.data_generators.translate_enmk",
     "tensor2tensor.data_generators.translate_envi",
     "tensor2tensor.data_generators.translate_enzh",

--- a/tensor2tensor/data_generators/translate_enid.py
+++ b/tensor2tensor/data_generators/translate_enid.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+# Copyright 2018 The Tensor2Tensor Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Data generators for En-Id translation."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# Dependency imports
+
+from tensor2tensor.data_generators import problem
+from tensor2tensor.data_generators import text_encoder
+from tensor2tensor.data_generators import translate
+from tensor2tensor.utils import registry
+
+# End-of-sentence marker.
+EOS = text_encoder.EOS_ID
+
+# IWSLT17 :
+# 	109335 sentences
+#	https://wit3.fbk.eu/mt.php?release=2017-01-more
+# PANL-BPPT :
+#	24024 sentences
+# 	http://www.panl10n.net/english/outputs/Indonesia/BPPT/0902/BPPTIndToEngCorpusHalfM.zip
+_ENID_TRAIN_DATASETS = [
+    [
+        "https://github.com/prasastoadi/parallel-corpora-en-id/raw/master/IWSLT17.train.en-id.tok.tgz",
+        ("IWSLT17.train.en-id.tok.en", "IWSLT17.train.en-id.tok.id")
+    ],
+    [
+        "https://github.com/prasastoadi/parallel-corpora-en-id/raw/master/PANL-BPPT-ECO-EN-ID-150Kw.tok.tgz",
+        ("PANL-BPPT-ECO-EN-150Kw.tok.txt", "PANL-BPPT-ECO-ID-150Kw.tok.txt")
+    ],
+    [
+        "https://github.com/prasastoadi/parallel-corpora-en-id/raw/master/PANL-BPPT-INT-EN-ID-150Kw.tok.tgz",
+        ("PANL-BPPT-INT-EN-150Kw.tok.txt", "PANL-BPPT-INT-ID-150Kw.tok.txt")
+    ],
+    [
+        "https://github.com/prasastoadi/parallel-corpora-en-id/raw/master/PANL-BPPT-SCI-EN-ID-100Kw.tok.tgz",
+        ("PANL-BPPT-SCI-EN-100Kw.tok.txt", "PANL-BPPT-SCI-ID-100Kw.tok.txt")
+    ],
+    [
+        "https://github.com/prasastoadi/parallel-corpora-en-id/raw/master/PANL-BPPT-SPO-EN-ID-100Kw.tok.tgz",
+        ("PANL-BPPT-SPO-EN-100Kw.tok.txt", "PANL-BPPT-SPO-ID-100Kw.tok.txt")
+    ],
+]
+
+# IWSLT17 :
+# 1478 sentences
+# https://wit3.fbk.eu/mt.php?release=2017-01-more
+_ENID_TEST_DATASETS = [
+    [
+        "https://github.com/prasastoadi/parallel-corpora-en-id/raw/master/IWSLT17.TED.tst2017plus.en-id.tok.tgz",
+        ("IWSLT17.TED.tst2017plus.en-id.tok.en", "IWSLT17.TED.tst2017plus.en-id.tok.id")
+    ]
+]
+
+
+@registry.register_problem
+class TranslateEnidIwslt32k(translate.TranslateProblem):
+  """Problem spec for IWSLT'15 En-Vi translation."""
+
+  @property
+  def approx_vocab_size(self):
+    return 2**15  # 32768
+
+  @property
+  def vocab_filename(self):
+    return "vocab.enid.%d" % self.approx_vocab_size
+
+  def source_data_files(self, dataset_split):
+    train = dataset_split == problem.DatasetSplit.TRAIN
+    return _ENID_TRAIN_DATASETS if train else _ENID_TEST_DATASETS


### PR DESCRIPTION
Add parallel corpora for English-Indonesian tasks. The sentences have been tokenized by using [SentencePiece](https://github.com/google/sentencepiece). Please refer to the following links for citation and the raw corpora.

[IWSLT17](https://wit3.fbk.eu/mt.php?release=2017-01-more) :
- train : 109335 sentences
- test : 1478 sentences

[PANL-BPPT](http://www.panl10n.net/english/OutputsIndonesia2.htm) : 24024 sentences