### PR TITLE
Python 3.6.5: UnicodeDecodeError: 'ascii' codec can't decode byte 0xff in position 0: ordinal not in range(128)

### DIFF
--- a/tensor2tensor/data_generators/cifar.py
+++ b/tensor2tensor/data_generators/cifar.py
@@ -92,7 +92,7 @@ def cifar_generator(cifar_version, tmp_dir, training, how_many, start_from=0):
   for filename in data_files:
     path = os.path.join(tmp_dir, prefix, filename)
     with tf.gfile.Open(path, "rb") as f:
-      data = cPickle.load(f)
+      data = cPickle.load(f, encoding='latin1')
     images = data["data"]
     num_images = images.shape[0]
     images = images.reshape((num_images, 3, image_size, image_size))


### PR DESCRIPTION
Hi everyone!
with `Python 3.6.5` the following exception will be thrown, when using the `tensor2tensor.data_generators.cifar.cifar_generator`: 

```
  File "/home/lhlmgr/anaconda3/lib/python3.6/site-packages/tensor2tensor/data_generators/cifar.py", line 146, in cifar_generator
    data = cPickle.load(f)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xff in position 0: ordinal not in range(128)
```

Adding the the parameter `encoding='latin1'` to `cPickle.load` fixes this error for the `cifar10` and `cifar100` (`/cifar20`) datasets.
However, I haven't tested the code with python 2.7..

(btw. thanks for your great work!)