### PR TITLE
Travis CI: Python syntax errors or undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ install:
   # Make sure we have the latest version of numpy - avoid problems we were
   # seeing with Python 3
   - pip install -q -U numpy
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  if [[ "$TF_VERSION" == "1.9.*" ]]; then
+    pip install flake8; flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics;
+  fi
 script:
   # Check import
   - python -c "from tensor2tensor.models import transformer; print(transformer.Transformer.__name__)"


### PR DESCRIPTION
Use [flake8](http://flake8.pycqa.org) to look for Python syntax errors or undefined names on both Python 2 and Python 3.

__E901,E999,F821,F822,F823__ are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc.  Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.  This PR therefore recommends a flake8 run of these tests on the entire codebase.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable `name` referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree