### PR TITLE
remove a mistakenly added new line which causes experiment failures

### DIFF
--- a/tensor2tensor/models/research/next_frame.py
+++ b/tensor2tensor/models/research/next_frame.py
@@ -27,7 +27,7 @@ from tensor2tensor.utils import registry
 from tensor2tensor.utils import t2t_model
 
 import tensorflow as tf
-from tensorflow_models.slim.nets.cyclegan import cyclegan_upsample
+
 tfl = tf.layers
 tfcl = tf.contrib.layers
 


### PR DESCRIPTION
Fixed a bug by removing one recently added extra line:
from tensorflow_models.slim.nets.cyclegan import cyclegan_upsample
in
tensor2tensor/models/research/next_frame.py