### PR TITLE
from six.moves import range for Python 3

### DIFF
--- a/tensor2tensor/models/research/universal_transformer_util.py
+++ b/tensor2tensor/models/research/universal_transformer_util.py
@@ -48,6 +48,8 @@ from __future__ import print_function
 import copy
 import functools
 
+from six.moves import range  # pylint: disable=redefined-builtin
+
 from tensor2tensor.layers import common_attention
 from tensor2tensor.layers import common_layers
 from tensor2tensor.models import transformer
@@ -227,7 +229,7 @@ def universal_transformer_layer(x,
       # and add position timing signal at the beginning of each step, so for
       # the vanilla transformer, we need to add timing signal here.
       x = common_attention.add_timing_signal_1d(x)
-    for layer in xrange(num_layers):
+    for layer in range(num_layers):
       with tf.variable_scope("layer_%d" % layer):
         x = ffn_unit(attention_unit(x))
     return x


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of __range()__ so convert all instances of __xrange()__ to __six.moves.range()__ for compatibility across Python 2 and Python 3.

Discovered via #942 at https://travis-ci.org/tensorflow/tensor2tensor/jobs/404819029#L1509