### PR TITLE
[FIX] broken universal_transformer_teeny

### DIFF
--- a/tensor2tensor/models/research/universal_transformer.py
+++ b/tensor2tensor/models/research/universal_transformer.py
@@ -477,7 +477,6 @@ def universal_transformer_tiny():
 @registry.register_hparams
 def transformer_teeny():
   hparams = transformer.transformer_base()
-  hparams.num_rec_steps = 2
   hparams.hidden_size = 128
   hparams.filter_size = 128
   hparams.num_heads = 2


### PR DESCRIPTION
universal_transformer_teeny() always fails with 

```
raise ValueError('Hyperparameter name is reserved: %s' % name)
ValueError: Hyperparameter name is reserved: num_rec_steps
```

This is because universal_transformer_teeny does

transformer_teeny => hparams.num_rec_steps = 2 => update_hparams_for_universal_transformer => tries to add num_rec_steps to hparams.

num_rec_steps is already in hparams, so it fails.  

Deleting num_rec_steps from transformer_teeny seemed like the most logical solution here.