### PR TITLE
Update universal_transformer_util.py fix bug TypeError

### DIFF
--- a/tensor2tensor/models/research/universal_transformer_util.py
+++ b/tensor2tensor/models/research/universal_transformer_util.py
@@ -578,7 +578,7 @@ def universal_transformer_basic(layer_inputs,
     layer_output:
          new_state: new state
   """
-  state, inputs, memory = layer_inputs
+  state, inputs, memory = tf.unstack(layer_inputs,num=None,axis=0,name="unstack")
   state = step_preprocess(state, step, hparams)
 
   new_state = ffn_unit(attention_unit(state))


### PR DESCRIPTION
TypeError: Tensor objects are not iterable when eager execution is not enabled. To iterate over this tensor use tf.map_fn.