### PR TITLE
Create problem transformer_timeseries_tpu and fix error "unexpected keyword argument 'drop_remainder' on TPU

### DIFF
--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -866,7 +866,7 @@ class Problem(object):
         # on TPU, we use params["batch_size"], which specifies the number of
         # examples across all datashards
         batch_size = params["batch_size"]
-        dataset = dataset.batch(batch_size, drop_remainder=True)
+        dataset = dataset.batch(batch_size)
       else:
         num_shards = config.data_parallelism.n if config else 1
         batch_size = hparams.batch_size * num_shards

--- a/tensor2tensor/models/transformer.py
+++ b/tensor2tensor/models/transformer.py
@@ -1953,6 +1953,13 @@ def transformer_tpu():
   update_hparams_for_tpu(hparams)
   return hparams
 
+@registry.register_hparams
+def transformer_timeseries_tpu():
+  """HParams for running Transformer model on timeseries on TPU."""
+  hparams = transformer_timeseries()
+  update_hparams_for_tpu(hparams)
+  hparams.batch_size = 256 # revert to value set in transformer_timeseries
+  return hparams
 
 @registry.register_hparams
 def transformer_tpu_bf16_activation():


### PR DESCRIPTION
1. Adds problem transformer_timeseries_tpu to problem.py
2. Fix error "unexpected keyword argument drop_remainder" for running transformer model on TPU