### PR TITLE
Create tensor2tensor/models/video/__init__.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - pip install "gym[atari]"
   # Make sure we have the latest version of numpy - avoid problems we were
   # seeing with Python 3
-  - pip install -q -U numpy
+  - pip install -q --upgrade matplotlib numpy
 script:
   # Check import
   - python -c "from tensor2tensor.models import transformer; print(transformer.Transformer.__name__)"

--- a/tensor2tensor/models/video/__init__.py
+++ b/tensor2tensor/models/video/__init__.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2018 The Tensor2Tensor Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
This file is required for __tensor2tensor.models.video__ to be a valid Python module.

@lukaszkaiser Was this a step missing from https://github.com/tensorflow/tensor2tensor/commit/03e889baf68664dda80414fcefd0d8bbaa5355c3 ?