### PR TITLE
bug fix for python 3 in Common Voice problem

### DIFF
--- a/tensor2tensor/data_generators/common_voice.py
+++ b/tensor2tensor/data_generators/common_voice.py
@@ -20,6 +20,7 @@ to have both SoX (http://sox.sourceforge.net) and on Linux, the libsox-fmt-mp3
 package installed. The original samples will be downsampled by the encoder.
 """
 
+import six
 import csv
 import os
 import tarfile
@@ -56,7 +57,11 @@ def _collect_data(directory):
     transcript_path = os.path.join(directory, transcript)
     with open(transcript_path, "r") as transcript_file:
       transcript_reader = csv.reader(transcript_file)
-      _ = transcript_reader.next()  # Skip headers.
+      # skip header
+      if six.PY3:
+        _ = next(transcript_reader)
+      else:
+        _ = transcript_reader.next()
       for transcript_line in transcript_reader:
         media_name, label = transcript_line[0:2]
         filename = os.path.join(directory, media_name)


### PR DESCRIPTION
### Description
Fixed bug in Common Voice problem 

Added specific conditional expression for Python 3.

Used the built-in function next in python 3:  next(reader) instead of reader.next() 

...

### Environment information

```

tensor2tensor==1.8.0
tensorboard==1.10.0
tensorflow==1.10.1

Python 3.6.5
```

### For bugs: reproduction and error logs

```
# Steps to reproduce:
1. Run datagen script for Common Voice problem (Python 3).
```

```
# Error logs:
tensor2tensor/tensor2tensor/data_generators/common_voice.py", line 59, in _collect_data
    _ = transcript_reader.next()  # Skip headers.
AttributeError: '_csv.reader' object has no attribute 'next'
```

