### PR TITLE
Fix and clean up universal transformer with depth-wise attention

### DIFF
--- a/tensor2tensor/models/research/universal_transformer.py
+++ b/tensor2tensor/models/research/universal_transformer.py
@@ -366,7 +366,7 @@ def update_hparams_for_universal_transformer(hparams):
   hparams.add_hparam("num_mixedin_layers", 2)
 
   # Type of recurrency:
-  # basic, highway, skip, dwa, act, rnn, gru, lstm.
+  # basic, act, highway, swsa, skip, gru, lstm.
   hparams.add_hparam("recurrence_type", "basic")
 
   # Number of steps (which is equivalent to num layer in transformer).
@@ -401,11 +401,12 @@ def update_hparams_for_universal_transformer(hparams):
   hparams.add_hparam("transform_bias_init", -1.0)
   hparams.add_hparam("couple_carry_transform_gates", True)
 
-  # Depth-wise attention (grid-transformer!) hparams:
-  # Adds depth embedding, if true.
-  hparams.add_hparam("depth_embedding", True)
-  # Learns attention weights for elements (instead of positions), if true.
-  hparams.add_hparam("dwa_elements", True)
+  # Hparams for swsa :
+  # Learns the step weights for elements (instead of positions), if true.
+  hparams.add_hparam("element_wise", True)
+  # If taking all the previuse steps into account, just in the final step (Flase)
+  # or in all the intermediate steps (True)
+  hparams.add_hparam("swsa_on_every_step", False)
 
   # Type of ffn_layer used for gate in skip, highway, etc.
   # "dense" or "dense_dropconnect".
@@ -415,7 +416,7 @@ def update_hparams_for_universal_transformer(hparams):
   # LSTM forget bias for lstm style recurrence.
   hparams.add_hparam("lstm_forget_bias", 1.0)
   # Uses the memory at the last step as the final output, if true.
-  hparams.add_hparam("use_memory_as_final_state", True)
+  hparams.add_hparam("use_memory_as_final_state", False)
   # if also add a ffn unit to the transition function when using gru/lstm
   hparams.add_hparam("add_ffn_unit_to_the_transition_function", False)
 
@@ -589,13 +590,6 @@ def universal_transformer_highway_base():
 
 
 @registry.register_hparams
-def universal_transformer_dwa_base():
-  hparams = universal_transformer_base()
-  hparams.recurrence_type = "dwa"
-  return hparams
-
-
-@registry.register_hparams
 def universal_transformer_lstm_base():
   hparams = universal_transformer_base()
   hparams.recurrence_type = "lstm"
@@ -618,6 +612,20 @@ def universal_transformer_lstm_tall():
   hparams.add_step_timing_signal = False  # Let lstm count in depth for us!
   return hparams
 
+
+@registry.register_hparams
+def universal_transformer_swsa_base():
+  hparams = universal_transformer_base()
+  hparams.recurrence_type = "swsa"
+  return hparams
+
+
+@registry.register_hparams
+def universal_transformer_swsa_every_step_base():
+  hparams = universal_transformer_base()
+  hparams.recurrence_type = "swsa"
+  hparams.swsa_on_every_step = True
+  return hparams
 
 @registry.register_hparams
 def universal_transformer_position_random_timing_tiny():

--- a/tensor2tensor/models/research/universal_transformer.py
+++ b/tensor2tensor/models/research/universal_transformer.py
@@ -404,8 +404,8 @@ def update_hparams_for_universal_transformer(hparams):
   # Hparams for swsa :
   # Learns the step weights for elements (instead of positions), if true.
   hparams.add_hparam("element_wise", True)
-  # If taking all the previuse steps into account, just in the final step (Flase)
-  # or in all the intermediate steps (True)
+  # Taking all the previuse steps into account, just in the final step (Flase)
+  # or in all the intermediate steps as well (True).
   hparams.add_hparam("swsa_on_every_step", False)
 
   # Type of ffn_layer used for gate in skip, highway, etc.

--- a/tensor2tensor/models/research/universal_transformer_util.py
+++ b/tensor2tensor/models/research/universal_transformer_util.py
@@ -767,13 +767,12 @@ def universal_transformer_stepwise_separable_attention(layer_inputs,
   this either for all the steps, or just the final step.
 
   We can imagine a grid universal transformer, where to encode each position in
-  each step, we can attend over all the positions in all the steps.
-  UT stepwise separable attention is a simple version of this idea and the
-  simplification is similar to the idea of separable
-  convolution as heren we first do the attention over all the position in each
-  step (step-wise attention) and then for each position, we do a point-wise
-  attention to attend over embeddings of that position learned in all the
-  previous steps.
+  each step, we can attend over all the positions in all the steps.  UT stepwise
+  separable attention is a simple version of this idea and the simplification is
+  similar to the idea of separable convolution as here we first do the attention
+  over all the positions in each step (step-wise attention) and then for each
+  position, we do a point-wise attention to attend over embeddings of that
+  position learned in all the  previous steps.
 
 
   Args:


### PR DESCRIPTION
Following the clean-up on the universal transformer with a gru/lstm as the transition function, I also fixed and cleaned up the code for another variant which was called depth-wise separable attention. 

I also changed the name to step-wise separable attention which is a better name as the action we take is similar to the depth-wise convolution.  In this variant of UT, i.e. stepwise separable attention,  we first do the attention over all the positions in each step (step-wise attention) and then for each position, we do a point-wise attention to attend over embeddings of that position learned in all the previous steps.