### PR TITLE
trainer_lib: add problem hparams after parsing the overrides

### DIFF
--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -89,12 +89,12 @@ def create_hparams(hparams_set,
   hparams = registry.hparams(hparams_set)
   if data_dir:
     hparams.add_hparam("data_dir", data_dir)
-  if problem_name:
-    add_problem_hparams(hparams, problem_name)
   if hparams_overrides_str:
     tf.logging.info("Overriding hparams in %s with %s", hparams_set,
                     hparams_overrides_str)
     hparams = hparams.parse(hparams_overrides_str)
+  if problem_name:
+    add_problem_hparams(hparams, problem_name)
   return hparams
 
 


### PR DESCRIPTION
t2t-trainer passes problem_name=None to create_hparams(), and
adds the problem hparams afterwards when creating the experiment.
t2t-decoder instead relies fully on create_hparams()
This inconsistency causes t2t-trainer and t2t-decoder to pass
different sets of model_hparams to Problem.hparams() (before and
after overrides respectively), which is problematic.

Always letting the problem see the final version of the model
hparams is more useful (in case the problem hparams depend on
the model), so make sure the problem is added after the overrides.