### PR TITLE
Avoid NaN while adding sinusoidal timing signals

### DIFF
--- a/tensor2tensor/layers/common_attention.py
+++ b/tensor2tensor/layers/common_attention.py
@@ -424,7 +424,7 @@ def get_timing_signal_1d(length,
   num_timescales = channels // 2
   log_timescale_increment = (
       math.log(float(max_timescale) / float(min_timescale)) /
-      (tf.to_float(num_timescales) - 1))
+      tf.maximum(tf.to_float(num_timescales) - 1), 1)
   inv_timescales = min_timescale * tf.exp(
       tf.to_float(tf.range(num_timescales)) * -log_timescale_increment)
   scaled_time = tf.expand_dims(position, 1) * tf.expand_dims(inv_timescales, 0)

--- a/tensor2tensor/layers/common_attention.py
+++ b/tensor2tensor/layers/common_attention.py
@@ -424,7 +424,7 @@ def get_timing_signal_1d(length,
   num_timescales = channels // 2
   log_timescale_increment = (
       math.log(float(max_timescale) / float(min_timescale)) /
-      tf.maximum(tf.to_float(num_timescales) - 1), 1)
+      tf.maximum(tf.to_float(num_timescales) - 1, 1))
   inv_timescales = min_timescale * tf.exp(
       tf.to_float(tf.range(num_timescales)) * -log_timescale_increment)
   scaled_time = tf.expand_dims(position, 1) * tf.expand_dims(inv_timescales, 0)


### PR DESCRIPTION
Tensors with less than 4 `channels` will get **NaN** in positional encodings.