### PR TITLE
Allow specifying which protocol to be used in tf.train.Server

### DIFF
--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -68,6 +68,7 @@ flags.DEFINE_integer("intra_op_parallelism_threads", 0,
 # definitions possibly erroring. Apologies for the ugliness.
 try:
   flags.DEFINE_string("master", "", "Address of TensorFlow master.")
+  flags.DEFINE_string("protocol", "grpc", "Protocol to be used.")
   flags.DEFINE_string("output_dir", "", "Base output directory for run.")
   flags.DEFINE_string("schedule", "continuous_train_and_eval",
                       "Method of Experiment to run.")
@@ -175,7 +176,8 @@ def create_experiment_fn():
       warm_start_from=FLAGS.warm_start_from,
       decode_from_file=FLAGS.decode_from_file,
       decode_to_file=FLAGS.decode_to_file,
-      decode_reference=FLAGS.decode_reference)
+      decode_reference=FLAGS.decode_reference,
+      protocol=FLAGS.protocol)
 
 
 def create_run_config(hp, output_dir=None):

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -391,7 +391,8 @@ class T2TExperiment(object):
     server = tf.train.Server(
         config.cluster_spec,
         job_name=config.task_type,
-        task_index=config.task_id)
+        task_index=config.task_id,
+        protocol=self._hparams.protocol)
     server.join()
 
   def decode(self, dataset_split=None, decode_from_file=False):
@@ -452,7 +453,8 @@ def create_experiment(
     warm_start_from=None,
     decode_from_file=None,
     decode_to_file=None,
-    decode_reference=None):
+    decode_reference=None,
+    protocol="grpc"):
   """Create Experiment."""
   # HParams
   hparams.add_hparam("model_dir", run_config.model_dir)
@@ -461,6 +463,7 @@ def create_experiment(
   hparams.add_hparam("eval_steps", eval_steps)
   hparams.add_hparam("schedule", schedule)
   hparams.add_hparam("warm_start_from", warm_start_from)
+  hparams.add_hparam("protocol", protocol)
   if decode_hparams is not None:
     decode_hparams.add_hparam("decode_from_file", decode_from_file)
     decode_hparams.add_hparam("decode_to_file", decode_to_file)


### PR DESCRIPTION
The patch allows user to specify which protocol to be used for distributed training. This enables the use of custom communication protocols (e.g. VERBS)