### PR TITLE
Fix world model evaluation

### DIFF
--- a/tensor2tensor/data_generators/gym_problems.py
+++ b/tensor2tensor/data_generators/gym_problems.py
@@ -743,8 +743,25 @@ class GymSimulatedDiscreteProblemForWorldModelEvalAutoencoded(
     GymSimulatedDiscreteProblemAutoencoded):
 
   def _generate_debug_image(self, real_ob, sim_ob):
-    # TODO(koz4k): Implement.
-    pass
+    def unpack(x):
+      return np.ndarray.astype(np.unpackbits(x, axis=2), np.int)
+    real_ob_unpacked = unpack(real_ob)
+    sim_ob_unpacked = unpack(sim_ob)
+    # Hamming distance on binary latent codes, seen as a grayscale image.
+    err = np.ndarray.astype(
+        np.transpose(
+            np.broadcast_to(
+                np.sum(
+                    np.abs(real_ob_unpacked - sim_ob_unpacked), axis=2
+                ) / 24.0 * 255,
+                # Channels first to satisfy numpy broadcasting rules.
+                shape=((real_ob.shape[2],) + real_ob.shape[:2])
+            ),
+            (1, 2, 0)
+        ),
+        np.uint8
+    )
+    return np.concatenate([sim_ob, real_ob, err], axis=1)
 
 
 @registry.register_problem

--- a/tensor2tensor/data_generators/gym_problems.py
+++ b/tensor2tensor/data_generators/gym_problems.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
 import json
 import math
 import os
@@ -492,14 +493,16 @@ class RewardPerSequenceStatistics(BasicStatistics):
   the correctness of rewards per sequence metric
   """
 
-  def __init__(self):
+  def __init__(self, rollout_fractions):
     super(RewardPerSequenceStatistics, self).__init__()
 
     # data to calculate
     # correctness of rewards per sequence metric
     self.episode_sim_reward = 0.0
     self.episode_real_reward = 0.0
-    self.successful_episode_reward_predictions = 0
+    self.successful_episode_reward_predictions = collections.OrderedDict([
+        (frac, 0) for frac in rollout_fractions
+    ])
     self.report_reward_statistics_every = 10
 
     # auxiliary objects
@@ -511,7 +514,7 @@ class RewardPerSequenceStatistics(BasicStatistics):
     keys_and_types = [
         ("episode_sim_reward", float),
         ("episode_real_reward", float),
-        ("successful_episode_reward_predictions", int),
+        ("successful_episode_reward_predictions", collections.OrderedDict),
         ("report_reward_statistics_every", int),
     ]
     additional = dict([(k, t(getattr(self, k))) for k, t in keys_and_types])
@@ -602,7 +605,7 @@ class GymSimulatedDiscreteProblemForWorldModelEval(GymSimulatedDiscreteProblem):
     super(GymSimulatedDiscreteProblemForWorldModelEval, self).__init__(
         *args, **kwargs
     )
-    self.statistics = RewardPerSequenceStatistics()
+    self.settable_rollout_fractions = [1]
 
   def get_environment_spec(self):
     env_spec = super(
@@ -612,6 +615,10 @@ class GymSimulatedDiscreteProblemForWorldModelEval(GymSimulatedDiscreteProblem):
     return env_spec
 
   def _setup(self, data_dir):
+    self.statistics = RewardPerSequenceStatistics(
+        self.settable_rollout_fractions
+    )
+
     trajectory_length = self.num_testing_steps
     if self.num_steps < 1200:
       # Decrease the trajectory length for tiny experiments, otherwise we don't
@@ -679,11 +686,14 @@ class GymSimulatedDiscreteProblemForWorldModelEval(GymSimulatedDiscreteProblem):
                 "The collect memory should be set in force_beginning_resets "
                 "mode for the code below to work properly.")
 
-    if (index+1) % self._internal_memory_size == 0:
+    index_in_rollout = index % self._internal_memory_size + 1
 
-      if stat.episode_sim_reward == stat.episode_real_reward:
-        stat.successful_episode_reward_predictions += 1
+    if stat.episode_sim_reward == stat.episode_real_reward:
+      for frac in stat.successful_episode_reward_predictions:
+        if index_in_rollout == int(self._internal_memory_size * frac):
+          stat.successful_episode_reward_predictions[frac] += 1
 
+    if index_in_rollout == self._internal_memory_size:
       stat.episode_sim_reward = 0.0
       stat.episode_real_reward = 0.0
       stat.number_of_dones += 1

--- a/tensor2tensor/data_generators/gym_problems.py
+++ b/tensor2tensor/data_generators/gym_problems.py
@@ -122,24 +122,24 @@ class GymDiscreteProblem(video_utils.VideoProblem):
                                  self._internal_memory_force_beginning_resets)
       collect_hparams.epoch_length = self._internal_memory_size
       collect_hparams.num_agents = 1
-  
+
       if not FLAGS.agent_policy_path:
         collect_hparams.policy_network = rl.random_policy_fun
-  
+
       if extra_collect_hparams is not None:
         for (key, value) in six.iteritems(extra_collect_hparams):
           collect_hparams.add_hparam(key, value)
-  
+
       if override_collect_hparams is not None:
         # Override hparams manually - HParams.override_from_dict does not work
         # with functions.
         for (key, value) in six.iteritems(override_collect_hparams):
           setattr(collect_hparams, key, value)
-  
+
       policy_to_actions_lambda = None
       if self.settable_eval_phase:
         policy_to_actions_lambda = lambda policy: policy.mode()
-  
+
       with tf.variable_scope(tf.get_variable_scope(), reuse=tf.AUTO_REUSE):
         self.collect_memory, self.collect_trigger_op, collect_init = (
             collect.define_collect(
@@ -148,7 +148,7 @@ class GymDiscreteProblem(video_utils.VideoProblem):
                 eval_phase=False,
                 collect_level=0,
                 policy_to_actions_lambda=policy_to_actions_lambda))
-  
+
       self._session = tf.Session()
       collect_init(self._session)
       self._session.run(tf.global_variables_initializer())

--- a/tensor2tensor/data_generators/gym_problems_specs.py
+++ b/tensor2tensor/data_generators/gym_problems_specs.py
@@ -27,7 +27,8 @@ from tensor2tensor.data_generators.gym_problems import GymDiscreteProblem,\
   GymSimulatedDiscreteProblem, GymRealDiscreteProblem, \
   GymDiscreteProblemWithAutoencoder, GymDiscreteProblemAutoencoded, \
   GymSimulatedDiscreteProblemAutoencoded, \
-  GymSimulatedDiscreteProblemForWorldModelEval
+  GymSimulatedDiscreteProblemForWorldModelEval, \
+  GymSimulatedDiscreteProblemForWorldModelEvalAutoencoded
 # pylint: enable=g-multiple-import
 from tensor2tensor.utils import registry
 
@@ -162,6 +163,21 @@ class GymSimulatedDiscreteProblemForWorldModelEvalWithAgentOnWrappedFullPong(
 class GymSimulatedDiscreteProblemWithAgentOnWrappedFullPongAutoencoded(
     GymSimulatedDiscreteProblemAutoencoded, GymWrappedFullPongRandom):
   """GymSimulatedDiscreteProblemWithAgentOnWrappedFullPongAutoencoded."""
+
+  @property
+  def initial_frames_problem(self):
+    return "gym_discrete_problem_with_agent_on_wrapped_full_pong_autoencoded"
+
+  @property
+  def num_testing_steps(self):
+    return 100
+
+
+@registry.register_problem
+class GymSimulatedDiscreteProblemForWorldModelEvalWithAgentOnWrappedFullPongAutoencoded(  # pylint: disable=line-too-long
+    GymSimulatedDiscreteProblemForWorldModelEvalAutoencoded,
+    GymWrappedFullPongRandom):
+  """Simulated pong for world model evaluation with encoded frames."""
 
   @property
   def initial_frames_problem(self):

--- a/tensor2tensor/data_generators/gym_problems_specs.py
+++ b/tensor2tensor/data_generators/gym_problems_specs.py
@@ -26,7 +26,8 @@ from tensor2tensor.data_generators import gym_utils  # pylint: disable=unused-im
 from tensor2tensor.data_generators.gym_problems import GymDiscreteProblem,\
   GymSimulatedDiscreteProblem, GymRealDiscreteProblem, \
   GymDiscreteProblemWithAutoencoder, GymDiscreteProblemAutoencoded, \
-  GymSimulatedDiscreteProblemAutoencoded
+  GymSimulatedDiscreteProblemAutoencoded, \
+  GymSimulatedDiscreteProblemForWorldModelEval
 # pylint: enable=g-multiple-import
 from tensor2tensor.utils import registry
 
@@ -144,6 +145,20 @@ class GymSimulatedDiscreteProblemWithAgentOnWrappedFullPong(
 
 
 @registry.register_problem
+class GymSimulatedDiscreteProblemForWorldModelEvalWithAgentOnWrappedFullPong(
+    GymSimulatedDiscreteProblemForWorldModelEval, GymWrappedFullPongRandom):
+  """Simulated pong for world model evaluation."""
+
+  @property
+  def initial_frames_problem(self):
+    return "gym_discrete_problem_with_agent_on_wrapped_full_pong"
+
+  @property
+  def num_testing_steps(self):
+    return 100
+
+
+@registry.register_problem
 class GymSimulatedDiscreteProblemWithAgentOnWrappedFullPongAutoencoded(
     GymSimulatedDiscreteProblemAutoencoded, GymWrappedFullPongRandom):
   """GymSimulatedDiscreteProblemWithAgentOnWrappedFullPongAutoencoded."""
@@ -230,10 +245,21 @@ def create_problems_for_game(
       })
   registry.register_problem(simulated_cls)
 
+  # Create and register the simulated Problem
+  world_model_eval_cls = type(
+      "GymSimulatedDiscreteProblemForWorldModelEvalWithAgentOn%s" %
+      camel_game_name,
+      (GymSimulatedDiscreteProblemForWorldModelEval, problem_cls), {
+          "initial_frames_problem": with_agent_cls.name,
+          "num_testing_steps": 100
+      })
+  registry.register_problem(world_model_eval_cls)
+
   return {
       "base": problem_cls,
       "agent": with_agent_cls,
       "simulated": simulated_cls,
+      "world_model_eval": world_model_eval_cls,
   }
 
 # Register the atari games with all of the possible modes.

--- a/tensor2tensor/rl/envs/batch_env_factory.py
+++ b/tensor2tensor/rl/envs/batch_env_factory.py
@@ -46,7 +46,8 @@ def batch_env_factory(hparams, xvfb=False):
   if environment_spec.simulated_env:
     # TODO(piotrmilos): Consider passing only relevant parameters
     cur_batch_env = _define_simulated_batch_env(
-        environment_spec, hparams.num_agents)
+        environment_spec, hparams.num_agents,
+        hparams.initial_frame_chooser)
   else:
     cur_batch_env = _define_batch_env(hparams.environment_spec,
                                       hparams.num_agents,
@@ -66,9 +67,11 @@ def _define_batch_env(environment_spec, num_agents, xvfb=False):
     return env
 
 
-def _define_simulated_batch_env(environment_spec, num_agents):
-  cur_batch_env = simulated_batch_env.SimulatedBatchEnv(environment_spec,
-                                                        num_agents)
+def _define_simulated_batch_env(environment_spec, num_agents,
+                                initial_frame_chooser):
+  cur_batch_env = simulated_batch_env.SimulatedBatchEnv(
+      environment_spec, num_agents, initial_frame_chooser
+  )
   return cur_batch_env
 
 

--- a/tensor2tensor/rl/envs/simulated_batch_env.py
+++ b/tensor2tensor/rl/envs/simulated_batch_env.py
@@ -29,8 +29,6 @@ from tensor2tensor.utils import trainer_lib
 
 import tensorflow as tf
 
-from tensorflow.contrib.training import HParams
-
 
 flags = tf.flags
 FLAGS = flags.FLAGS
@@ -39,13 +37,9 @@ FLAGS = flags.FLAGS
 class HistoryBuffer(object):
   """History Buffer."""
 
-  def __init__(self, input_dataset, length, observ_dtype, start_frame=None):
-    if start_frame is None:
-      dataset = input_dataset.batch(length)
-    else:
-      dataset = input_dataset.batch(length - 1)
-      dataset = dataset.map(lambda x: tf.concat([start_frame, x], axis=0))
-    self.input_data_iterator = dataset.make_initializable_iterator()
+  def __init__(self, initial_frame_chooser, length, observ_dtype):
+    initial_frame_chooser.batch_size = length
+    self._initial_frame_chooser = initial_frame_chooser
     self.length = length
     self._observ_dtype = observ_dtype
     initial_frames = self.get_initial_observations()
@@ -54,10 +48,12 @@ class HistoryBuffer(object):
                                      trainable=False)
 
   def initialize(self, sess):
-    sess.run(self.input_data_iterator.initializer)
+    self._initial_frame_chooser.initialize(sess)
 
   def get_initial_observations(self):
-    return tf.cast(self.input_data_iterator.get_next(), self._observ_dtype)
+    return tf.cast(
+        self._initial_frame_chooser.choose()["inputs"], self._observ_dtype
+    )
 
   def get_all_elements(self):
     return self._history_buff.read_value()
@@ -102,7 +98,7 @@ class SimulatedBatchEnv(in_graph_batch_env.InGraphBatchEnv):
   flags are held in according variables.
   """
 
-  def __init__(self, environment_spec, length):
+  def __init__(self, environment_spec, length, initial_frame_chooser):
     """Batch of environments inside the TensorFlow graph."""
 
     observ_space = utils.get_observation_space(environment_spec)
@@ -125,34 +121,8 @@ class SimulatedBatchEnv(in_graph_batch_env.InGraphBatchEnv):
     self._model = registry.model(FLAGS.model)(
         model_hparams, tf.estimator.ModeKeys.PREDICT)
 
-    hparams = HParams(video_num_input_frames=
-                      environment_spec.video_num_input_frames,
-                      video_num_target_frames=
-                      environment_spec.video_num_target_frames,
-                      environment_spec=environment_spec)
-
-    # TODO(piotrmilos): check if this shouldn't be tf.estimator.ModeKeys.Predict
-    initial_frames_dataset = initial_frames_problem.dataset(
-        tf.estimator.ModeKeys.TRAIN, FLAGS.data_dir, shuffle_files=False,
-        hparams=hparams).take(1)
-    start_frame = None
-    if environment_spec.simulation_random_starts:
-      dataset = initial_frames_problem.dataset(tf.estimator.ModeKeys.TRAIN,
-                                               FLAGS.data_dir,
-                                               shuffle_files=True,
-                                               hparams=hparams,
-                                               only_last=True)
-      dataset = dataset.shuffle(buffer_size=1000)
-      if environment_spec.simulation_flip_first_random_for_beginning:
-        # Later flip the first random frame in PPO batch for the true beginning.
-        start = initial_frames_dataset.make_one_shot_iterator().get_next()
-        start_frame = tf.expand_dims(start["inputs"], axis=0)
-    else:
-      dataset = initial_frames_dataset
-
-    dataset = dataset.map(lambda x: x["inputs"]).repeat()
     self.history_buffer = HistoryBuffer(
-        dataset, self.length, self.observ_dtype, start_frame=start_frame)
+        initial_frame_chooser, self.length, self.observ_dtype)
 
     self._observ = tf.Variable(
         tf.zeros((len(self),) + observ_shape, self.observ_dtype),

--- a/tensor2tensor/rl/envs/utils.py
+++ b/tensor2tensor/rl/envs/utils.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import gym
+import six
 import tensorflow as tf
 
 
@@ -134,3 +135,129 @@ def parse_dtype(space):
   if isinstance(space, gym.spaces.Box):
     return tf.as_dtype(space.dtype)
   raise NotImplementedError()
+
+
+class InitialFrameChooser(object):
+  """Class for choosing the initial frame for simulation from the dataset.
+
+  Can also store a sequence of later frames, which is used for comparison in
+  world model evaluation.
+
+  Attributes:
+    batch_size (int): Batch size, should be set before calling choose().
+    trajectory (dict): Dict of Variables storing a sequence of frames after the
+        chosen one.
+  """
+
+  def __init__(self, environment_spec, mode, trajectory_length=1):
+    self._initial_frames_problem = environment_spec.initial_frames_problem
+    self._simulation_random_starts = environment_spec.simulation_random_starts
+    self._flip_first_random_for_beginning = \
+        environment_spec.simulation_flip_first_random_for_beginning
+    self._num_initial_frames = environment_spec.video_num_input_frames
+
+    def dataset_kwargs_lambda():
+      video_num_input_frames = environment_spec.video_num_input_frames
+      video_num_input_frames += trajectory_length - 1
+      dataset_hparams = tf.contrib.training.HParams(
+          video_num_input_frames=video_num_input_frames,
+          video_num_target_frames=environment_spec.video_num_target_frames,
+          environment_spec=environment_spec
+      )
+      return {
+          "mode": mode,
+          "data_dir": tf.flags.FLAGS.data_dir,
+          "hparams": dataset_hparams
+      }
+
+    self._dataset_kwargs_lambda = dataset_kwargs_lambda
+    self._start_frames = None
+
+  @property
+  def batch_size(self):
+    return self._batch_size
+
+  @batch_size.setter
+  def batch_size(self, batch_size):
+    self._batch_size = batch_size
+    self._iterator = \
+        self._create_initial_frame_dataset().make_initializable_iterator()
+
+    def fix_and_shorten(shape):
+      shape = shape.as_list()
+      shape[0] = batch_size
+      shape[1] -= self._num_initial_frames - 1
+      return shape
+
+    shapes = self._extract_input(self._iterator.output_shapes)
+    types = self._extract_input(self._iterator.output_types)
+    self.trajectory = {
+        key: tf.Variable(
+            tf.zeros(fix_and_shorten(shape), types[key]),
+            trainable=False
+        )
+        for (key, shape) in six.iteritems(shapes)
+    }
+
+  def initialize(self, sess):
+    sess.run(self._iterator.initializer)
+
+  def choose(self):
+    """Returns a dict of tensors of the chosen initial frame.
+
+    Also assigns the first trajectory_length frames after the initial frames to
+    self.trajectory.
+    """
+    if self._flip_first_random_for_beginning and self._start_frames is None:
+      ordered_dataset = self._create_dataset(shuffle_files=False)
+      # Later flip the first random frame in PPO batch for the true beginning.
+      self._start_frames = self._extract_input(
+          ordered_dataset.make_one_shot_iterator().get_next()
+      )
+
+    all_frames = self._extract_input(self._iterator.get_next())
+    if self._start_frames is not None:
+      all_frames = {
+          key: tf.concat([
+              tf.expand_dims(self._start_frames[key], axis=0),
+              value[1:, ...]
+          ], axis=0)
+          for (key, value) in six.iteritems(all_frames)
+      }
+    scatter_ops = [
+        tf.scatter_update(
+            self.trajectory[key], tf.range(tf.shape(value)[0]),
+            value[:, (self._num_initial_frames - 1):, ...]
+        )
+        for (key, value) in six.iteritems(all_frames)
+    ]
+
+    with tf.control_dependencies(scatter_ops):
+      return {
+          key: value[:, :self._num_initial_frames, ...]
+          for (key, value) in six.iteritems(all_frames)
+      }
+
+  def _create_dataset(self, **extra_dataset_kwargs):
+    dataset_kwargs = self._dataset_kwargs_lambda()
+    dataset_kwargs.update(extra_dataset_kwargs)
+    return self._initial_frames_problem.dataset(**dataset_kwargs)
+
+  def _create_initial_frame_dataset(self):
+    """Returns the dataset that consecutive initial frames will be taken from.
+    """
+    dataset = self._create_dataset(
+        shuffle_files=self._simulation_random_starts
+    )
+    if self._simulation_random_starts:
+      dataset = dataset.shuffle(buffer_size=1000)
+    return dataset.repeat().batch(self._batch_size)
+
+  def _extract_input(self, frame):
+    input_frame = {"inputs": frame["inputs"]}
+    input_frame.update({
+        key[len("input_"):]: value
+        for (key, value) in six.iteritems(frame)
+        if key.startswith("input_")
+    })
+    return input_frame

--- a/tensor2tensor/rl/envs/utils.py
+++ b/tensor2tensor/rl/envs/utils.py
@@ -167,7 +167,8 @@ class InitialFrameChooser(object):
       return {
           "mode": mode,
           "data_dir": tf.flags.FLAGS.data_dir,
-          "hparams": dataset_hparams
+          "hparams": dataset_hparams,
+          "only_last": True
       }
 
     self._dataset_kwargs_lambda = dataset_kwargs_lambda

--- a/tensor2tensor/rl/trainer_model_based.py
+++ b/tensor2tensor/rl/trainer_model_based.py
@@ -468,6 +468,10 @@ def training_loop(hparams, output_dir, report_fn=None, report_metric=None):
     simulated_problem_name = (
         "gym_simulated_discrete_problem_with_agent_on_%s_autoencoded"
         % game_with_mode)
+    world_model_eval_problem_name = (
+        "gym_simulated_discrete_problem_for_world_model_eval_with_agent_on_%s" \
+        "_autoencoded"
+        % game_with_mode)
   else:
     problem_name = ("gym_discrete_problem_with_agent_on_%s" % game_with_mode)
     world_model_problem = problem_name
@@ -872,7 +876,6 @@ def rl_modelrl_ae_tiny():
   hparams.ppo_params = "ppo_pong_ae_base"
   hparams.generative_model_params = "next_frame_ae"
   hparams.autoencoder_train_steps = 2
-  hparams.eval_world_model = False
   return hparams
 
 

--- a/tensor2tensor/rl/trainer_model_based.py
+++ b/tensor2tensor/rl/trainer_model_based.py
@@ -294,6 +294,8 @@ def evaluate_world_model(simulated_problem_name, problem_name, hparams,
   gym_simulated_problem = registry.problem(simulated_problem_name)
   sim_steps = hparams.simulated_env_generator_num_steps
   gym_simulated_problem.settable_num_steps = sim_steps
+  gym_simulated_problem.settable_rollout_fractions = \
+      hparams.eval_rollout_fractions
   with temporary_flags({
       "problem": problem_name,
       "model": hparams.generative_model,
@@ -303,9 +305,13 @@ def evaluate_world_model(simulated_problem_name, problem_name, hparams,
   }):
     gym_simulated_problem.generate_data(epoch_data_dir, tmp_dir)
   n = max(1., gym_simulated_problem.statistics.number_of_dones)
-  model_reward_accuracy = (
-      gym_simulated_problem.statistics.successful_episode_reward_predictions
-      / float(n))
+  model_reward_accuracy = [
+      (frac, score / float(n))
+      for (frac, score) in six.iteritems(
+          gym_simulated_problem.statistics.
+          successful_episode_reward_predictions
+      )
+  ]
   old_path = os.path.join(epoch_data_dir, "debug_frames_sim")
   new_path = os.path.join(epoch_data_dir, "debug_frames_sim_eval")
   if not tf.gfile.Exists(new_path):
@@ -508,8 +514,11 @@ def training_loop(hparams, output_dir, report_fn=None, report_metric=None):
                                         "eval_metrics_event_dir")
   eval_metrics_writer = tf.summary.FileWriter(eval_metrics_event_dir)
   model_reward_accuracy_summary = tf.Summary()
-  model_reward_accuracy_summary.value.add(tag="model_reward_accuracy",
-                                          simple_value=None)
+  for frac in hparams.eval_rollout_fractions:
+    model_reward_accuracy_summary.value.add(
+        tag="model_reward_accuracy_{}".format(frac),
+        simple_value=None
+    )
   mean_reward_summary = tf.Summary()
   mean_reward_summary.value.add(tag="mean_reward",
                                 simple_value=None)
@@ -544,14 +553,17 @@ def training_loop(hparams, output_dir, report_fn=None, report_metric=None):
                       directories["world_model"], hparams, epoch)
 
     # Evaluate world model
-    model_reward_accuracy = 0.
+    model_reward_accuracy = []
     if hparams.eval_world_model:
       log("Evaluating world model")
       model_reward_accuracy = evaluate_world_model(
           world_model_eval_problem_name, world_model_problem, hparams,
           directories["world_model"],
           epoch_data_dir, directories["tmp"])
-      log("World model reward accuracy: %.4f", model_reward_accuracy)
+      log(
+          "World model reward accuracy per rollout fraction: %s",
+          model_reward_accuracy
+      )
 
     # Train PPO
     log("Training PPO in simulated environment.")
@@ -592,15 +604,21 @@ def training_loop(hparams, output_dir, report_fn=None, report_metric=None):
     # Summarize metrics
     assert model_reward_accuracy is not None
     assert mean_reward is not None
-    model_reward_accuracy_summary.value[0].simple_value = model_reward_accuracy
+    for ((_, accuracy), summary_value) in zip(
+        model_reward_accuracy, model_reward_accuracy_summary.value
+    ):
+      summary_value.simple_value = accuracy
     mean_reward_summary.value[0].simple_value = mean_reward
     eval_metrics_writer.add_summary(model_reward_accuracy_summary, epoch)
     eval_metrics_writer.add_summary(mean_reward_summary, epoch)
     eval_metrics_writer.flush()
 
     # Report metrics
-    eval_metrics = {"model_reward_accuracy": model_reward_accuracy,
-                    "mean_reward": mean_reward}
+    eval_metrics = {"mean_reward": mean_reward}
+    eval_metrics.update({
+        "model_reward_accuracy_{}".format(frac): accuracy
+        for (frac, accuracy) in model_reward_accuracy
+    })
     epoch_metrics.append(eval_metrics)
     log("Eval metrics: %s", str(eval_metrics))
     if report_fn:
@@ -677,6 +695,8 @@ def rl_modelrl_base():
       # Whether to evaluate the world model in each iteration of the loop to get
       # the model_reward_accuracy metric.
       eval_world_model=True,
+      # Rollout fractions to report reward_accuracy on.
+      eval_rollout_fractions=[0.25, 0.5, 1],
       stop_loop_early=False,  # To speed-up tests.
   )
 


### PR DESCRIPTION
Now the world model is evaluated by comparing frames from the simulated environment and those from the real environment, read from disk.
The evaluation trajectory starts from a random frame.
When resetting SimulatedBatchEnv, a number of extra frames after the initial ones are read and used as the reference trajectory in world model evaluation (class InitialFrameChooser).
Actions played in the simulated environment are taken from real trajectories, this is done by mocking the policy network to output fixed actions.