### PR TITLE
Expose method model() to load a model from registry

### DIFF
--- a/tensor2tensor/models/__init__.py
+++ b/tensor2tensor/models/__init__.py
@@ -67,4 +67,9 @@ from tensor2tensor.models.video import epva
 from tensor2tensor.models.video import savp
 from tensor2tensor.models.video import sv2p
 
+from tensor2tensor.utils import registry
+
 # pylint: enable=unused-import
+
+def model(name):
+  return registry.model(name)


### PR DESCRIPTION
For consistency, since we can write

```python
from tensor2tensor import problems
problem = problems.problem('my_problem')
```

this should work for the module `models` too:

```python
from tensor2tensor import models
model = models.model('my_model')
```