### PR TITLE
Avoid a ascii codec error in CNN/DailyMail.

### DIFF
--- a/tensor2tensor/data_generators/cnn_dailymail.py
+++ b/tensor2tensor/data_generators/cnn_dailymail.py
@@ -182,9 +182,9 @@ def write_raw_text_to_files(all_files, urls_path, dataset_split, tmp_dir):
   """Write text to files."""
 
   def write_to_file(all_files, urls_path, tmp_dir, filename):
-    with io.open(os.path.join(tmp_dir, filename + ".source"), "w") as fstory:
+    with io.open(os.path.join(tmp_dir, filename + ".source"), "w", encoding="utf-8") as fstory:
       with io.open(os.path.join(tmp_dir, filename + ".target"),
-                   "w") as fsummary:
+                   "w", encoding="utf-8") as fsummary:
         for example in example_generator(all_files, urls_path, sum_token=True):
           story, summary = _story_summary_split(example)
           fstory.write(story + "\n")


### PR DESCRIPTION
When a basic `t2t-trainer` command is run with the `--problem=summarize_cnn_dailymail32k` command, the following error occurs:

```
UnicodeEncodeError: 'ascii' codec can't encode character '\xbb' in position 1426: ordinal not in range(128)
```

This minor fix resolves this issue.

Fixes issue #1068