### PR TITLE
Speed up autoencoder test

### DIFF
--- a/tensor2tensor/data_generators/gym_problems.py
+++ b/tensor2tensor/data_generators/gym_problems.py
@@ -89,9 +89,10 @@ def standard_atari_env_eval_spec(env, simulated=False,
       include_clipping=False)
 
 
-def standard_atari_ae_env_spec(env):
+def standard_atari_ae_env_spec(env, ae_hparams_set):
   """Parameters of environment specification."""
-  standard_wrappers = [[tf_atari_wrappers.AutoencoderWrapper, {}],
+  standard_wrappers = [[tf_atari_wrappers.AutoencoderWrapper,
+                        {"ae_hparams_set": ae_hparams_set}],
                        [tf_atari_wrappers.StackWrapper, {"history": 4}]]
   env_lambda = None
   if isinstance(env, str):
@@ -476,7 +477,7 @@ class GymDiscreteProblemWithAutoencoder(GymRealDiscreteProblem):
     self._forced_collect_level = 0
 
   def get_environment_spec(self):
-    return standard_atari_ae_env_spec(self.env_name)
+    return standard_atari_ae_env_spec(self.env_name, self.ae_hparams_set)
 
   def restore_networks(self, sess):
     super(GymDiscreteProblemWithAutoencoder, self).restore_networks(sess)
@@ -517,12 +518,12 @@ class GymDiscreteProblemAutoencoded(GymRealDiscreteProblem):
                        " for reading encoded frames")
 
   def get_environment_spec(self):
-    return standard_atari_ae_env_spec(self.env_name)
+    return standard_atari_ae_env_spec(self.env_name, self.ae_hparams_set)
 
   @property
   def autoencoder_factor(self):
     """By how much to divide sizes when using autoencoders."""
-    hparams = autoencoders.autoencoder_discrete_pong()
+    hparams = registry.hparams(self.ae_hparams_set)
     return 2**hparams.num_hidden_layers
 
   @property
@@ -796,7 +797,7 @@ class GymSimulatedDiscreteProblemAutoencoded(GymSimulatedDiscreteProblem):
   @property
   def autoencoder_factor(self):
     """By how much to divide sizes when using autoencoders."""
-    hparams = autoencoders.autoencoder_discrete_pong()
+    hparams = registry.hparams(self.ae_hparams_set)
     return 2**hparams.num_hidden_layers
 
   @property

--- a/tensor2tensor/data_generators/gym_problems_specs.py
+++ b/tensor2tensor/data_generators/gym_problems_specs.py
@@ -227,7 +227,8 @@ def create_problems_for_game(
     game_name,
     resize_height_factor=1,
     resize_width_factor=1,
-    game_mode="Deterministic-v4"):
+    game_mode="Deterministic-v4",
+    autoencoder_hparams=None):
   """Create and register problems for game_name.
 
   Args:
@@ -259,36 +260,74 @@ def create_problems_for_game(
                       "resize_width_factor": resize_width_factor})
   registry.register_problem(problem_cls)
 
-  with_agent_cls = type("GymDiscreteProblemWithAgentOn%s" % camel_game_name,
-                        (GymRealDiscreteProblem, problem_cls), {})
+  if not autoencoder_hparams:
+    with_agent_cls = type("GymDiscreteProblemWithAgentOn%s" % camel_game_name,
+                          (GymRealDiscreteProblem, problem_cls), {})
+    registry.register_problem(with_agent_cls)
 
-  registry.register_problem(with_agent_cls)
+    # Create and register the simulated Problem
+    simulated_cls = type(
+        "GymSimulatedDiscreteProblemWithAgentOn%s" % camel_game_name,
+        (GymSimulatedDiscreteProblem, problem_cls), {
+            "initial_frames_problem": with_agent_cls.name,
+            "num_testing_steps": 100
+        })
+    registry.register_problem(simulated_cls)
 
-  # Create and register the simulated Problem
-  simulated_cls = type(
-      "GymSimulatedDiscreteProblemWithAgentOn%s" % camel_game_name,
-      (GymSimulatedDiscreteProblem, problem_cls), {
-          "initial_frames_problem": with_agent_cls.name,
-          "num_testing_steps": 100
-      })
-  registry.register_problem(simulated_cls)
+    # Create and register the simulated Problem
+    world_model_eval_cls = type(
+        "GymSimulatedDiscreteProblemForWorldModelEvalWithAgentOn%s" %
+        camel_game_name,
+        (GymSimulatedDiscreteProblemForWorldModelEval, problem_cls), {
+            "initial_frames_problem": with_agent_cls.name,
+            "num_testing_steps": 100
+        })
+    registry.register_problem(world_model_eval_cls)
+    return {
+        "base": problem_cls,
+        "agent": with_agent_cls,
+        "simulated": simulated_cls,
+        "world_model_eval": world_model_eval_cls,
+    }
+  else:
+    with_agent_cls_with_ae = \
+      type("GymDiscreteProblemWithAgentOn%sWithAutoencoder" % camel_game_name,
+           (GymDiscreteProblemWithAutoencoder, problem_cls),
+           {'ae_hparams_set': autoencoder_hparams})
+    registry.register_problem(with_agent_cls_with_ae)
 
-  # Create and register the simulated Problem
-  world_model_eval_cls = type(
-      "GymSimulatedDiscreteProblemForWorldModelEvalWithAgentOn%s" %
-      camel_game_name,
-      (GymSimulatedDiscreteProblemForWorldModelEval, problem_cls), {
-          "initial_frames_problem": with_agent_cls.name,
-          "num_testing_steps": 100
-      })
-  registry.register_problem(world_model_eval_cls)
+    with_agent_cls_ae = \
+      type("GymDiscreteProblemWithAgentOn%sAutoencoded" % camel_game_name,
+           (GymDiscreteProblemAutoencoded, problem_cls),
+           {"ae_hparams_set": autoencoder_hparams})
+    registry.register_problem(with_agent_cls_ae)
 
-  return {
-      "base": problem_cls,
-      "agent": with_agent_cls,
-      "simulated": simulated_cls,
-      "world_model_eval": world_model_eval_cls,
-  }
+    # Create and register the simulated Problem
+    simulated_cls = \
+      type("GymSimulatedDiscreteProblemWithAgentOn%sAutoencoded"
+           % camel_game_name,
+           (GymSimulatedDiscreteProblemAutoencoded, problem_cls), {
+               "initial_frames_problem": with_agent_cls_ae.name,
+               "num_testing_steps": 100,
+               "ae_hparams_set": autoencoder_hparams})
+    registry.register_problem(simulated_cls)
+
+    world_model_eval_cls = \
+      type("GymSimulatedDiscreteProblemForWorldModelEvalWithAgentOn%sAutoencoded"  # pylint: disable=line-too-long
+           % camel_game_name,
+           (GymSimulatedDiscreteProblemForWorldModelEvalAutoencoded,
+            problem_cls), {
+                "initial_frames_problem": with_agent_cls_ae.name,
+                "num_testing_steps": 100,
+                "ae_hparams_set": autoencoder_hparams})
+    registry.register_problem(world_model_eval_cls)
+    return {
+        "base": problem_cls,
+        "agent_with_ae": with_agent_cls_with_ae,
+        "agent_ae": with_agent_cls_ae,
+        "simulated_ae": simulated_cls,
+        "world_model_eval_ae": world_model_eval_cls,
+    }
 
 # Register the atari games with all of the possible modes.
 for game in ATARI_ALL_MODES_SHORT_LIST:

--- a/tensor2tensor/models/research/autoencoders.py
+++ b/tensor2tensor/models/research/autoencoders.py
@@ -1209,6 +1209,23 @@ def autoencoder_discrete_pong():
 
 
 @registry.register_hparams
+def autoencoder_discrete_tiny():
+  """Discrete autoencoder model for compressing pong frames.
+  Tiny version for testing."""
+  hparams = autoencoder_ordered_discrete()
+  hparams.num_hidden_layers = 2
+  hparams.bottleneck_bits = 24
+  hparams.batch_size = 2
+  hparams.gan_loss_factor = 0.
+  hparams.bottleneck_l2_factor = 0.001
+  hparams.add_hparam("video_modality_loss_cutoff", 0.02)
+  hparams.num_residual_layers = 1
+  hparams.hidden_size = 32
+  hparams.max_hidden_size = 64
+  return hparams
+
+
+@registry.register_hparams
 def autoencoder_discrete_cifar():
   """Discrete autoencoder model for compressing cifar."""
   hparams = autoencoder_ordered_discrete()

--- a/tensor2tensor/models/video/basic_deterministic_params.py
+++ b/tensor2tensor/models/video/basic_deterministic_params.py
@@ -94,6 +94,16 @@ def next_frame_ae():
 
 
 @registry.register_hparams
+def next_frame_ae_tiny():
+  """Conv autoencoder, tiny set for testing."""
+  hparams = next_frame_tiny()
+  hparams.input_modalities = "inputs:video:bitwise"
+  hparams.batch_size = 8
+  hparams.dropout = 0.4
+  return hparams
+
+
+@registry.register_hparams
 def next_frame_small():
   """Small conv model."""
   hparams = next_frame_basic_deterministic()

--- a/tensor2tensor/rl/envs/tf_atari_wrappers.py
+++ b/tensor2tensor/rl/envs/tf_atari_wrappers.py
@@ -221,13 +221,14 @@ class StackWrapper(WrapperBase):
 class AutoencoderWrapper(WrapperBase):
   """Transforms the observations taking the bottleneck of an autoencoder."""
 
-  def __init__(self, batch_env):
+  def __init__(self, batch_env, ae_hparams_set):
     super(AutoencoderWrapper, self).__init__(batch_env)
+    self.ae_hparams_set = ae_hparams_set
     self._observ = tf.Variable(
         tf.zeros((len(self),) + self.observ_shape, self.observ_dtype),
         trainable=False)
     with tf.variable_scope(tf.get_variable_scope(), reuse=tf.AUTO_REUSE):
-      autoencoder_hparams = autoencoders.autoencoder_discrete_pong()
+      autoencoder_hparams = registry.hparams(self.ae_hparams_set)
       problem = registry.problem("dummy_autoencoder_problem")
       autoencoder_hparams.problem_hparams = problem.get_hparams(
           autoencoder_hparams)
@@ -249,7 +250,7 @@ class AutoencoderWrapper(WrapperBase):
   @property
   def autoencoder_factor(self):
     """By how much to divide sizes when using autoencoders."""
-    hparams = autoencoders.autoencoder_discrete_pong()
+    hparams = registry.hparams(self.ae_hparams_set)
     return 2**hparams.num_hidden_layers
 
   def simulate(self, action):

--- a/tensor2tensor/rl/trainer_model_based.py
+++ b/tensor2tensor/rl/trainer_model_based.py
@@ -149,7 +149,7 @@ def train_autoencoder(problem_name, data_dir, output_dir, hparams, epoch):
       "data_dir": data_dir,
       "output_dir": output_dir,
       "model": "autoencoder_ordered_discrete",
-      "hparams_set": "autoencoder_discrete_pong",
+      "hparams_set": hparams.autoencoder_hparams_set,
       "train_steps": train_steps,
       "eval_steps": 100,
   }):
@@ -406,11 +406,11 @@ def encode_dataset(model, dataset, problem, ae_hparams, autoencoder_path,
         cycle_every_n=problem.total_number_of_frames // 10)
 
 
-def encode_env_frames(problem_name, ae_problem_name, autoencoder_path,
-                      epoch_data_dir):
+def encode_env_frames(problem_name, ae_problem_name, ae_hparams_set,
+                      autoencoder_path, epoch_data_dir):
   """Encode all frames from problem_name and write out as ae_problem_name."""
   with tf.Graph().as_default():
-    ae_hparams = trainer_lib.create_hparams("autoencoder_discrete_pong",
+    ae_hparams = trainer_lib.create_hparams(ae_hparams_set,
                                             problem_name=problem_name)
     problem = ae_hparams.problem
     model = registry.model("autoencoder_ordered_discrete")(
@@ -436,16 +436,17 @@ def encode_env_frames(problem_name, ae_problem_name, autoencoder_path,
       dataset = problem.dataset(tf.estimator.ModeKeys.TRAIN, epoch_data_dir,
                                 shuffle_files=False, output_buffer_size=100,
                                 preprocess=False)
-      encode_dataset(model, dataset, problem, ae_hparams, autoencoder_path,
-                     ae_training_paths)
+      encode_dataset(model, dataset, problem=problem, ae_hparams=ae_hparams,
+                     autoencoder_path=autoencoder_path,
+                     out_files=ae_training_paths)
 
     # Encode eval data
     if not skip_eval:
       dataset = problem.dataset(tf.estimator.ModeKeys.EVAL, epoch_data_dir,
                                 shuffle_files=False, output_buffer_size=100,
                                 preprocess=False)
-      encode_dataset(model, dataset, problem, ae_hparams, autoencoder_path,
-                     ae_eval_paths)
+      encode_dataset(model, dataset, problem=problem, ae_hparams=ae_hparams,
+                     autoencoder_path=autoencoder_path, out_files=ae_eval_paths)
 
 
 def check_problems(problem_names):
@@ -459,8 +460,11 @@ def setup_problems(hparams, using_autoencoder=False):
     game_with_mode = hparams.game + "_deterministic-v4"
   else:
     game_with_mode = hparams.game
+  game_problems_kwargs = {}
   # Problems
   if using_autoencoder:
+    game_problems_kwargs['autoencoder_hparams'] = \
+      hparams.autoencoder_hparams_set
     problem_name = (
         "gym_discrete_problem_with_agent_on_%s_with_autoencoder"
         % game_with_mode)
@@ -474,6 +478,8 @@ def setup_problems(hparams, using_autoencoder=False):
         "_autoencoded"
         % game_with_mode)
   else:
+    game_problems_kwargs['resize_height_factor'] = hparams.resize_height_factor
+    game_problems_kwargs['resize_width_factor'] = hparams.resize_width_factor
     problem_name = ("gym_discrete_problem_with_agent_on_%s" % game_with_mode)
     world_model_problem = problem_name
     simulated_problem_name = ("gym_simulated_discrete_problem_with_agent_on_%s"
@@ -481,14 +487,11 @@ def setup_problems(hparams, using_autoencoder=False):
     world_model_eval_problem_name = (
         "gym_simulated_discrete_problem_for_world_model_eval_with_agent_on_%s"
         % game_with_mode)
-    if problem_name not in registry.list_problems():
-      tf.logging.info("Game Problem %s not found; dynamically registering",
-                      problem_name)
-      gym_problems_specs.create_problems_for_game(
-          hparams.game,
-          resize_height_factor=hparams.resize_height_factor,
-          resize_width_factor=hparams.resize_width_factor,
-          game_mode="Deterministic-v4")
+  if problem_name not in registry.list_problems():
+    tf.logging.info("Game Problem %s not found; dynamically registering",
+                    problem_name)
+    gym_problems_specs.create_problems_for_game(
+        hparams.game, game_mode="Deterministic-v4", **game_problems_kwargs)
   return (problem_name, world_model_problem, simulated_problem_name,
           world_model_eval_problem_name)
 
@@ -578,7 +581,9 @@ def training_loop(hparams, output_dir, report_fn=None, report_metric=None):
 
       log("Autoencoding environment frames")
       encode_env_frames(problem_name, world_model_problem,
-                        autoencoder_model_dir, epoch_data_dir)
+                        ae_hparams_set=hparams.autoencoder_hparams_set,
+                        autoencoder_path=autoencoder_model_dir,
+                        epoch_data_dir=epoch_data_dir)
 
     # Train world model
     log("Training world model")
@@ -1138,6 +1143,7 @@ def rlmb_ae_base():
   hparams = rlmb_base()
   hparams.ppo_params = "ppo_pong_ae_base"
   hparams.generative_model_params = "next_frame_ae"
+  hparams.autoencoder_hparams_set = 'autoencoder_discrete_pong'
   hparams.gather_ppo_real_env_data = False
   hparams.autoencoder_train_steps = 30000
   return hparams
@@ -1147,13 +1153,14 @@ def rlmb_ae_base():
 def rlmb_ae_tiny():
   """Tiny set for testing autoencoders."""
   hparams = rlmb_tiny()
-  hparams.game = "wrapped_full_pong"
   hparams.ppo_params = "ppo_pong_ae_base"
-  hparams.generative_model_params = "next_frame_ae"
+  hparams.generative_model_params = "next_frame_ae_tiny"
+  hparams.autoencoder_hparams_set = 'autoencoder_discrete_tiny'
   hparams.gather_ppo_real_env_data = False
   hparams.resize_height_factor = 1
   hparams.resize_width_factor = 1
   hparams.autoencoder_train_steps = 2
+  hparams.stop_loop_early = False
   return hparams
 
 

--- a/tensor2tensor/rl/trainer_model_based_ae_test.py
+++ b/tensor2tensor/rl/trainer_model_based_ae_test.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-# from tensor2tensor.rl import trainer_model_based
+from tensor2tensor.rl import trainer_model_based
 
 import tensorflow as tf
 
@@ -27,11 +27,10 @@ FLAGS = tf.flags.FLAGS
 class ModelRLExperimentTestAe(tf.test.TestCase):
 
   def test_ae(self):
-    # FLAGS.output_dir = tf.test.get_temp_dir()
-    # FLAGS.loop_hparams_set = "rlmb_ae_tiny"
-    # FLAGS.schedule = "train"  # skip evaluation for world model training
-    # trainer_model_based.main(None)
-    pass
+    FLAGS.output_dir = tf.test.get_temp_dir()
+    FLAGS.loop_hparams_set = "rlmb_ae_tiny"
+    FLAGS.schedule = "train"  # skip evaluation for world model training
+    trainer_model_based.main(None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Speed up autoencoder test (in model-based rl pipeline). Enable passing autoencoder hparams by flags; dynamically construct autoencoder related problems; autoencoder wrappers are constructed with hparams_set.