### PR TITLE
Adding experiment delagate callback to t2t-trainer main-method

### DIFF
--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -341,7 +341,7 @@ def run_std_server():
   exp.run_std_server()
 
 
-def main(argv):
+def main(argv, experiment_delegate=None):
   tf.logging.set_verbosity(tf.logging.INFO)
   if FLAGS.schedule == "run_std_server":
     run_std_server()
@@ -367,7 +367,11 @@ def main(argv):
   exp = exp_fn(create_run_config(hparams), hparams)
   if is_chief():
     save_metadata(hparams)
-  execute_schedule(exp)
+
+  if experiment_delegate:
+    experiment_delegate(exp)
+  else:
+    execute_schedule(exp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I would like to propose an optional argument to the `t2t_trainer.main()` method and a branch depending on wether it has been passed or not:

```python
def main(argv, experiment_delegate=None):
  # ...
  if experiment_delegate:
    experiment_delegate(exp)
  else:
    execute_schedule(exp)
```

This would allow to simply pass the created experiment back to an outside caller where a custom schedule can be implemented:

```python
import sys
from bin import t2t_trainer

def my_custom_experiment_schedule(experiment):
  experiment.train(10000)
  # Do something in between ..
  experiment.eval()
  print('All done')

if __name__ == '__main__':
  sys.argv += [
    # .. params
  ]

  t2t_trainer.main(None, experiment_delegate=my_custom_experiment_schedule)
```

I've been struggling to find an easier way to do this. The major problem I am currently seeking is that `SessionRunHook` does not allow me to modify of create a new graph during a continuous training schedule.

Please excuse me if there's already a simpler solution to this but after investigating the code I figured that the above would be the easiest solution. The `experiment_delegate` doesn't necessarily have to be a parameter of the `main()` method if one wraps the required code inside a wrapper function of course.
