### PR TITLE
Passing hook context to train and eval hooks

### DIFF
--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -159,11 +159,11 @@ class T2TModel(base.Layer):
   # Replace the two methods below in order to add custom SessionRunHooks to
   # the training procedure.
   @staticmethod
-  def train_hooks():
+  def train_hooks(hook_context):
     return []
 
   @staticmethod
-  def eval_hooks():
+  def eval_hooks(hook_context):
     return []
 
   @property
@@ -1215,14 +1215,14 @@ class T2TModel(base.Layer):
     return features
 
   @staticmethod
-  def get_train_hooks(model_name):
+  def get_train_hooks(model_name, hook_context):
     model_cls = registry.model(model_name)
-    return model_cls.train_hooks()
+    return model_cls.train_hooks(hook_context)
 
   @staticmethod
-  def get_eval_hooks(model_name):
+  def get_eval_hooks(model_name, hook_context):
     model_cls = registry.model(model_name)
-    return model_cls.eval_hooks()
+    return model_cls.eval_hooks(hook_context)
 
   @staticmethod
   def make_estimator_model_fn(model_name,

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
 import json
 import os
 import random
@@ -321,6 +322,12 @@ def create_hooks(use_tfdbg=False,
   return train_hooks, eval_hooks
 
 
+class HookContext(collections.namedtuple(
+  "HookContext",
+  ["estimator", "problem", "hparams"])):
+  pass
+
+
 class T2TExperiment(object):
   """Custom Experiment class for running distributed experiments."""
 
@@ -565,8 +572,11 @@ def create_experiment(
       validation_monitor_kwargs=validation_monitor_kwargs,
       use_early_stopping=use_early_stopping,
       early_stopping_kwargs=early_stopping_kwargs)
-  train_hooks += t2t_model.T2TModel.get_train_hooks(model_name)
-  eval_hooks += t2t_model.T2TModel.get_eval_hooks(model_name)
+
+  hook_context = HookContext(estimator=estimator, problem=problem, hparams=hparams)
+
+  train_hooks += t2t_model.T2TModel.get_train_hooks(model_name, hook_context)
+  eval_hooks += t2t_model.T2TModel.get_eval_hooks(model_name, hook_context)
   if additional_train_hooks:
     train_hooks += additional_train_hooks
   if additional_eval_hooks:


### PR DESCRIPTION
This might make my previously proposed PR https://github.com/tensorflow/tensor2tensor/pull/1154 obsolete.

In `trainer_lib.py`, the `train_hooks()` and `eval_hooks()` of the `T2TModel` are getting called. These are `static` methods which means we cannot access the `self` reference and further not the model's `hparams`. Therefore, any hook created in `train_hooks()` or `eval_hooks()` is lacking context information. At least until now I was not able to find an obvious way to retrieve additional required information for my hooks. For more context, `train_hooks()` and `eval_hooks()` should provide a `hook_context` object. 

The (arguably) simplest way at this point would be to pass a `hook_context` in `trainer_lib.py`. So instead of

```python
train_hooks += t2t_model.T2TModel.get_train_hooks(model_name)
eval_hooks += t2t_model.T2TModel.get_eval_hooks(model_name)
```
we have:
```python
hook_context = HookContextArgs(estimator=estimator, problem=problem, hparams=hparams)

train_hooks += t2t_model.T2TModel.get_train_hooks(model_name, hook_context)
eval_hooks += t2t_model.T2TModel.get_eval_hooks(model_name, hook_context)
```

where `hook_context` is

```python
class HookContext(collections.namedtuple(
  "HookContext",
  ["estimator", "problem", "hparams"])):
  pass
```

and both hook-providing methods are getting the same, which would allow the following:




```python
import tensorflow as tf
from tensor2tensor.utils import registry
from tensor2tensor import models


class HookWithContext(tf.train.SessionRunHook):

  def __init__(self, hook_context):
    self.estimator = hook_context.estimator
    self.hparams = hook_context.hparams

  def begin(self):
    p = self.hparams
    print(p.model_dir)  # Model location
    print(p.problem.filepattern(p.data_dir, 'test'))  # Filepattern for test set


@registry.register_model
class ShakeShakeExt(models.shake_shake.ShakeShake):

  def __init__(self, *args, **kwargs):
    super().__init__(*args, **kwargs)

  @staticmethod
  def eval_hooks(hook_context):
    return [ HookWithContext(hook_context) ]
```