### PR TITLE
Model-Based RL: Fix short rollouts in initial_frames_number

### DIFF
--- a/tensor2tensor/data_generators/gym_env.py
+++ b/tensor2tensor/data_generators/gym_env.py
@@ -87,11 +87,7 @@ class T2TEnv(video_utils.VideoProblem):
   def __init__(self, batch_size, *args, **kwargs):
     super(T2TEnv, self).__init__(*args, **kwargs)
 
-    self.clear_history()
     self.batch_size = batch_size
-    self._current_batch_frames = [None for _ in range(batch_size)]
-    self._current_batch_rollouts = [[] for _ in range(batch_size)]
-    self._current_epoch_rollouts = []
     self._rollouts_by_epoch_and_split = collections.OrderedDict()
     self.current_epoch = None
     with tf.Graph().as_default() as tf_graph:
@@ -108,10 +104,6 @@ class T2TEnv(video_utils.VideoProblem):
     """Returns a string representation of the environment for debug purposes."""
     raise NotImplementedError
 
-  def clear_history(self):
-    """Clears the rollout history."""
-    self._rollouts_by_epoch_and_split = collections.OrderedDict()
-
   def start_new_epoch(self, epoch, load_data_dir=None):
     if not isinstance(epoch, int):
       raise ValueError("Epoch should be integer, got {}".format(epoch))
@@ -120,10 +112,14 @@ class T2TEnv(video_utils.VideoProblem):
     self.current_epoch = epoch
     self._current_epoch_rollouts = []
     self._rollouts_by_epoch_and_split[epoch] = collections.defaultdict(list)
+    self._current_batch_frames = [None for _ in range(self.batch_size)]
+    self._current_batch_rollouts = [[] for _ in range(self.batch_size)]
     if load_data_dir is not None:
       self._load_epoch_data(load_data_dir)
 
-  def current_epoch_rollouts(self, split=None):
+  def current_epoch_rollouts(self, split=None, minimal_rollout_frames=0):
+    # TODO(KC): order of rollouts (by splits) is a bit uncontrolled
+    # (rollouts_by_split.values() reads dict values), is it a problem?
     rollouts_by_split = self._rollouts_by_epoch_and_split[self.current_epoch]
     if not rollouts_by_split:
       if split is not None:
@@ -131,15 +127,18 @@ class T2TEnv(video_utils.VideoProblem):
             "generate_data() should first be called in the current epoch"
         )
       else:
-        return self._current_epoch_rollouts
-    if split is not None:
-      return rollouts_by_split[split]
+        rollouts = self._current_epoch_rollouts
     else:
-      return [
-          rollout
-          for rollouts in rollouts_by_split.values()
-          for rollout in rollouts
-      ]
+      if split is not None:
+        rollouts = rollouts_by_split[split]
+      else:
+        rollouts = [
+            rollout
+            for rollouts in rollouts_by_split.values()
+            for rollout in rollouts
+        ]
+    return [rollout for rollout in rollouts
+            if len(rollout) >= minimal_rollout_frames]
 
   def _preprocess_observations(self, obs):
     """Transforms a batch of observations.

--- a/tensor2tensor/data_generators/gym_env_test.py
+++ b/tensor2tensor/data_generators/gym_env_test.py
@@ -49,9 +49,8 @@ class TestEnv(gym.Env):
     self._counter = 0
 
   def _generate_ob(self):
-    return np.zeros(
-        self.observation_space.shape, self.observation_space.dtype
-    )
+    return np.random.randint(255, size=self.observation_space.shape,
+                             dtype=self.observation_space.dtype)
 
   def step(self, action):
     done = self._counter % 2 == 1
@@ -79,10 +78,11 @@ class GymEnvTest(tf.test.TestCase):
     self.out_dir = tf.test.get_temp_dir()
     shutil.rmtree(self.out_dir)
     os.mkdir(self.out_dir)
+    np.random.seed(0)
 
-  def init_batch_and_play(self, env_name, steps_per_epoch=1,
-                          epochs=(0,), generate_data=False, **kwargs):
-    env = gym_env.T2TGymEnv(env_name, batch_size=2, **kwargs)
+  def init_batch_and_play(self, env_name, steps_per_epoch=1, epochs=(0,),
+                          generate_data=False, batch_size=2, **kwargs):
+    env = gym_env.T2TGymEnv(env_name, batch_size=batch_size, **kwargs)
     obs = list()
     rewards = list()
     num_dones = 0
@@ -90,6 +90,7 @@ class GymEnvTest(tf.test.TestCase):
       env.start_new_epoch(epoch, self.out_dir)
       _, epoch_obs, epoch_rewards, epoch_num_dones = \
           self.play(env, steps_per_epoch)
+      epoch_obs.append(env.reset())
       if generate_data:
         env.generate_data(self.out_dir)
       obs.extend(epoch_obs)
@@ -121,21 +122,26 @@ class GymEnvTest(tf.test.TestCase):
       self.assertTrue(env.current_epoch_rollouts(split))
 
   def test_split_preserves_number_of_rollouts(self):
+    batch_size = 2
     env, _, _, num_dones = self.init_batch_and_play(
-        TEST_ENV_NAME, steps_per_epoch=20, generate_data=True
+        TEST_ENV_NAME, steps_per_epoch=20, generate_data=True,
+        batch_size=batch_size
     )
 
     num_rollouts_after_split = sum(
         len(env.current_epoch_rollouts(split)) for split in self.splits
     )
-    # Number of rollouts could be increased by one in case a rollout is broken
-    # on a boundary between the dataset splits.
-    self.assertGreaterEqual(num_rollouts_after_split, num_dones)
-    self.assertLessEqual(num_rollouts_after_split, num_dones + 1)
+    # After the end of epoch all environments are reset, which increases number
+    # of rollouts by batch size. Number of rollouts could be increased by one
+    # in case a rollout is broken on a boundary between the dataset splits.
+    self.assertGreaterEqual(num_rollouts_after_split, num_dones + batch_size)
+    self.assertLessEqual(num_rollouts_after_split, num_dones + batch_size + 1)
 
   def test_split_preserves_number_of_frames(self):
+    batch_size = 2
     env, _, _, num_dones = self.init_batch_and_play(
-        TEST_ENV_NAME, steps_per_epoch=20, generate_data=True
+        TEST_ENV_NAME, steps_per_epoch=20, generate_data=True,
+        batch_size=batch_size
     )
 
     num_frames = sum(
@@ -144,8 +150,9 @@ class GymEnvTest(tf.test.TestCase):
         for rollout in env.current_epoch_rollouts(split)
     )
     # There are 3 frames in every rollout: the initial one and two returned by
-    # step().
-    self.assertEqual(num_frames, 3 * num_dones)
+    # step(). Additionally there are batch_size observations comming from final
+    # reset at the end of epoch.
+    self.assertEqual(num_frames, 3 * num_dones + batch_size)
 
   def test_generates_data(self):
     # This test needs base env which outputs done after two steps.


### PR DESCRIPTION
T2TEnv: Full history cleaning on new epoch (fix); read only rollouts with size appropriate for initial_frame_chooser; initial_frame_chooser fix for simulation_random_starts case (unused so far);

Full cleaning of history in T2TGymEnv resolves bug with short rollout in initial_frames, but in the principle these kind of rollouts might be produced by environment anyway, so explicit filtering is also applied.

Moving indentation in change_initial_frames fixes potential bug which have not appeared yet (case "not environment_spec.simulation_random_starts" is not used currently)