### PR TITLE
variable_scope wrapper for avg_checkpoints

### DIFF
--- a/tensor2tensor/utils/avg_checkpoints.py
+++ b/tensor2tensor/utils/avg_checkpoints.py
@@ -89,10 +89,11 @@ def main(_):
   for name in var_values:  # Average.
     var_values[name] /= len(checkpoints)
 
-  tf_vars = [
-      tf.get_variable(v, shape=var_values[v].shape, dtype=var_dtypes[name])
-      for v in var_values
-  ]
+  with tf.variable_scope(tf.get_variable_scope(), reuse=tf.AUTO_REUSE):
+      tf_vars = [
+          tf.get_variable(v, shape=var_values[v].shape, dtype=var_dtypes[v])
+          for v in var_values
+      ]
   placeholders = [tf.placeholder(v.dtype, shape=v.shape) for v in tf_vars]
   assign_ops = [tf.assign(v, p) for (v, p) in zip(tf_vars, placeholders)]
   global_step = tf.Variable(


### PR DESCRIPTION
During training, you might need to run avg_checkpoints a couple of times and generate different checkpoints. In that case, you need to reuse the variables you've made in the previous session calls.