### PR TITLE
Pass data_dir to feature_encoders

### DIFF
--- a/tensor2tensor/data_generators/common_voice.py
+++ b/tensor2tensor/data_generators/common_voice.py
@@ -134,7 +134,7 @@ class CommonVoice(speech_recognition.SpeechRecognitionProblem):
 
     data_dir = os.path.join(tmp_dir, "cv_corpus_v1")
     data_tuples = _collect_data(data_dir)
-    encoders = self.feature_encoders(None)
+    encoders = self.feature_encoders(data_dir)
     audio_encoder = encoders["waveforms"]
     text_encoder = encoders["targets"]
     for dataset in datasets:

--- a/tensor2tensor/data_generators/librispeech.py
+++ b/tensor2tensor/data_generators/librispeech.py
@@ -138,7 +138,7 @@ class Librispeech(speech_recognition.SpeechRecognitionProblem):
       data_files = _collect_data(data_dir, "flac", "txt")
       data_pairs = data_files.values()
 
-      encoders = self.feature_encoders(None)
+      encoders = self.feature_encoders(data_dir)
       audio_encoder = encoders["waveforms"]
       text_encoder = encoders["targets"]
 


### PR DESCRIPTION
The reason is that we cannot do this at the moment:

```python
class LibrispeechMod(Librispeech):

  def feature_encoders(self, data_dir):
    return {
      # ..
      'targets': MyCustomEncoder(data_dir)
    }
```

because at the moment `feature_encoders()` is getting called by passing `None` (see [Librispeech](https://github.com/tensorflow/tensor2tensor/blob/v1.9.0/tensor2tensor/data_generators/librispeech.py#L140) and [CommonVoice](https://github.com/tensorflow/tensor2tensor/blob/v1.9.0/tensor2tensor/data_generators/common_voice.py#L136))

```python
def generator_(self, data_dir, tmp_dir, datasets, eos_list=None, start_from=0, how_many=0):
    # ..
    encoders = self.feature_encoders(None)
    audio_encoder = encoders["waveforms"]
    text_encoder = encoders["targets"]
    # ..
```