### PR TITLE
 Fixing error passing wrong data_dir

### DIFF
--- a/tensor2tensor/data_generators/common_voice.py
+++ b/tensor2tensor/data_generators/common_voice.py
@@ -132,8 +132,8 @@ class CommonVoice(speech_recognition.SpeechRecognitionProblem):
       ]
       corpus_tar.extractall(tmp_dir, members=members)
 
-    data_dir = os.path.join(tmp_dir, "cv_corpus_v1")
-    data_tuples = _collect_data(data_dir)
+    raw_data_dir = os.path.join(tmp_dir, "cv_corpus_v1")
+    data_tuples = _collect_data(raw_data_dir)
     encoders = self.feature_encoders(data_dir)
     audio_encoder = encoders["waveforms"]
     text_encoder = encoders["targets"]

--- a/tensor2tensor/data_generators/common_voice.py
+++ b/tensor2tensor/data_generators/common_voice.py
@@ -134,7 +134,7 @@ class CommonVoice(speech_recognition.SpeechRecognitionProblem):
 
     data_dir = os.path.join(tmp_dir, "cv_corpus_v1")
     data_tuples = _collect_data(data_dir)
-    encoders = self.feature_encoders(None)
+    encoders = self.feature_encoders(data_dir)
     audio_encoder = encoders["waveforms"]
     text_encoder = encoders["targets"]
     for dataset in datasets:

--- a/tensor2tensor/data_generators/librispeech.py
+++ b/tensor2tensor/data_generators/librispeech.py
@@ -138,7 +138,7 @@ class Librispeech(speech_recognition.SpeechRecognitionProblem):
       data_files = _collect_data(data_dir, "flac", "txt")
       data_pairs = data_files.values()
 
-      encoders = self.feature_encoders(None)
+      encoders = self.feature_encoders(data_dir)
       audio_encoder = encoders["waveforms"]
       text_encoder = encoders["targets"]
 

--- a/tensor2tensor/data_generators/librispeech.py
+++ b/tensor2tensor/data_generators/librispeech.py
@@ -134,8 +134,8 @@ class Librispeech(speech_recognition.SpeechRecognitionProblem):
             members.append(f)
         corpus_tar.extractall(tmp_dir, members=members)
 
-      data_dir = os.path.join(tmp_dir, "LibriSpeech", subdir)
-      data_files = _collect_data(data_dir, "flac", "txt")
+      raw_data_dir = os.path.join(tmp_dir, "LibriSpeech", subdir)
+      data_files = _collect_data(raw_data_dir, "flac", "txt")
       data_pairs = data_files.values()
 
       encoders = self.feature_encoders(data_dir)


### PR DESCRIPTION
In [my pr](https://github.com/tensorflow/tensor2tensor/commit/c6c5cb5862f8229bf2694192959ba2feaf793a9c) I did not realize that `data_dir` gets modified an re-assigned. `feature_encoders()` should receive the *actual* `data_dir` and not the modified version. 

I'm sorry for any inconveniences. 