### PR TITLE
Fixing weight initialization in symbols modality

### DIFF
--- a/tensor2tensor/layers/modalities.py
+++ b/tensor2tensor/layers/modalities.py
@@ -143,7 +143,7 @@ class SymbolModality(modality.Modality):
 
     if self._model_hparams.shared_embedding_and_softmax_weights:
       scope_name = "shared"
-      reuse = True
+      reuse = tf.AUTO_REUSE
     else:
       scope_name = "softmax"
       reuse = False


### PR DESCRIPTION
Changed reuse val from true to tf.AUTO_REUSE in top to allow for proper weight initialization