### PR TITLE
[UT] small bugs in ut_function when one uses data length = 1

### DIFF
--- a/tensor2tensor/models/research/universal_transformer_util.py
+++ b/tensor2tensor/models/research/universal_transformer_util.py
@@ -1182,7 +1182,7 @@ def universal_transformer_act_basic(x, hparams, ffn_unit, attention_unit):
           state_shape[0],
           state_shape[1],
       ])
-      new_state.set_shape(state_shape)
+    new_state.set_shape(state_shape)
     step += 1
     return (transformed_state, step, halting_probability, remainders, n_updates,
             new_state)
@@ -1472,7 +1472,7 @@ def universal_transformer_act_global(x, hparams, ffn_unit, attention_unit):
       x.set_shape([
           state_shape[0],
       ])
-      new_state.set_shape(state_shape)
+    new_state.set_shape(state_shape)
 
     step += 1
     return [
@@ -1620,7 +1620,7 @@ def universal_transformer_act_random(x, hparams, ffn_unit, attention_unit):
           state_shape[0],
           state_shape[1],
       ])
-      new_state.set_shape(state_shape)
+    new_state.set_shape(state_shape)
     step += 1
     return [
         transformed_state, step, halting_probability, remainders, n_updates,

--- a/tensor2tensor/models/research/universal_transformer_util.py
+++ b/tensor2tensor/models/research/universal_transformer_util.py
@@ -1133,7 +1133,7 @@ def universal_transformer_act_basic(x, hparams, ffn_unit, attention_unit):
           use_bias=True,
           bias_initializer=tf.constant_initializer(
               hparams.act_halting_bias_init))
-      p = tf.squeeze(p)
+      p = tf.squeeze(p, axis=-1)
 
     # Mask for inputs which have not halted yet
     still_running = tf.cast(tf.less(halting_probability, 1.0), tf.float32)
@@ -1285,7 +1285,7 @@ def universal_transformer_act_accumulated(x, hparams, ffn_unit, attention_unit):
           use_bias=True,
           bias_initializer=tf.constant_initializer(
               hparams.act_halting_bias_init))
-      p = tf.squeeze(p)
+      p = tf.squeeze(p, axis=-1)
 
     # Mask for inputs which have not halted yet
     still_running = tf.cast(tf.less(halting_probability, 1.0), tf.float32)


### PR DESCRIPTION
# Summary

I found and fixed small bugs in UT implements in special case `length=1` for `universal_transformer_util.py`.
Addition to that, I fixed an operation by having some codes out of loop which looks meaningless iteration (this is not main).

# Bugs Detail

I found bugs on a special case in `universal_transformer_util.py`:

- squeeze operations in `ut_function` without axis make the dimensions unknown and fail successive operation
  - [L1136](https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/models/research/universal_transformer_util.py#L1136), [L1288](https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/models/research/universal_transformer_util.py#L1288)

The flow for L1136 is below:

1.  the dimensions of state is `[batch_size, length, channel]` as mentioned in comment at [L1110](https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/models/research/universal_transformer_util.py#L1110)
2. it reduce to `[batch_size, length, 1]` in `common_layers.dense` at [L1129](https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/models/research/universal_transformer_util.py#L1129)
3. `p` is `[batch_size, length]` by `p = tf.squeeze(p)` at [L1136](https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/models/research/universal_transformer_util.py#L1136)

In this case, the shape of `p` would be unknown if `length = 1` after squeeze operation, and that may makes successive operation fail.

# Modification Detail

There are 2 modifications:

- assign axis at `tf.squeeze` in ut_function
  - I don't fix L1363 because it has `reduce_mean` operation before `squeeze`.
- have `new_state.set_shape(state_shape)` out of loop because it looks meaningless 👀 

 It's ok to revert latter one because it is not a main fix.