### PR TITLE
Model-Based RL: Split hparams dependent/indepent of RL algorithm (ppo/dqn)

### DIFF
--- a/tensor2tensor/rl/trainer_model_based.py
+++ b/tensor2tensor/rl/trainer_model_based.py
@@ -291,11 +291,9 @@ def evaluate_single_config(hparams, stochastic, max_num_noops, agent_model_dir):
       agent_model_dir=agent_model_dir
   )
   learner.evaluate(env_fn, eval_hparams, stochastic)
-  rollouts = env.current_epoch_rollouts()[:hparams.eval_batch_size]
+  rollouts = env.current_epoch_rollouts()
   env.close()
 
-  assert len(rollouts) == hparams.eval_batch_size, \
-      "{} {}".format(len(rollouts), hparams.eval_batch_size)
   return tuple(
       compute_mean_reward(rollouts, clipped) for clipped in (True, False)
   )

--- a/tensor2tensor/rl/trainer_model_based_params.py
+++ b/tensor2tensor/rl/trainer_model_based_params.py
@@ -43,8 +43,7 @@ flags.DEFINE_string("eval_results_dir", "/tmp",
 HP_SCOPES = ["loop", "model", "ppo"]
 
 
-@registry.register_hparams
-def rlmb_base():
+def _rlmb_base():
   return tf.contrib.training.HParams(
       epochs=15,
       # Total frames used for training. This will be distributed evenly across
@@ -54,31 +53,16 @@ def rlmb_base():
       num_real_env_frames=96000,
       generative_model="next_frame_basic_deterministic",
       generative_model_params="next_frame_pixel_noise",
-      base_algo="ppo",
-      base_algo_params="ppo_original_params",
       autoencoder_train_steps=0,
       autoencoder_train_steps_initial_multiplier=10,
       autoencoder_hparams_set="autoencoder_discrete_pong",
       model_train_steps=15000,
       initial_epoch_train_steps_multiplier=3,
-      simulation_random_starts=True,  # Use random starts in PPO.
+      # Use random starts when learning agent on simulated env.
+      simulation_random_starts=True,
       # Flip the first random frame in PPO batch for the true beginning.
       simulation_flip_first_random_for_beginning=True,
       intrinsic_reward_scale=0.,
-      # Number of real environments to train on simultaneously.
-      real_batch_size=1,
-      # Number of simulated environments to train on simultaneously.
-      simulated_batch_size=16,
-      # Number of frames that can be taken from the simulated environment before
-      # it diverges, used for training the agent.
-      simulated_rollout_length=50,
-      ppo_epochs_num=1000,  # This should be enough to see something
-      # Should be equal to simulated_rollout_length.
-      # TODO(koz4k): Uncouple this by outputing done from SimulatedBatchEnv.
-      ppo_epoch_length=50,
-      # Do not eval since simulated batch env does not produce dones
-      ppo_eval_every_epochs=0,
-      ppo_learning_rate=1e-4,  # Will be changed, just so it exists.
       # Resizing.
       resize_height_factor=2,
       resize_width_factor=2,
@@ -93,17 +77,8 @@ def rlmb_base():
       # In your experiments, you want to optimize this rate to your schedule.
       learning_rate_bump=3.0,
 
-      # Unused; number of PPO epochs is calculated from the real frame limit.
-      real_ppo_epochs_num=0,
-      # This needs to be divisible by real_ppo_effective_num_agents.
-      real_ppo_epoch_length=16*200,
-      real_ppo_learning_rate=1e-4,
-      real_ppo_effective_num_agents=16,
-      real_ppo_eval_every_epochs=0,
-
       # Batch size during evaluation. Metrics are averaged over this number of
       # rollouts.
-      eval_batch_size=30,
       eval_max_num_noops=8,
 
       game="pong",
@@ -120,7 +95,66 @@ def rlmb_base():
       env_timesteps_limit=-1,  # Use default from gym.make()
       # Number of last observations to feed to the agent and world model.
       frame_stack_size=4,
+      # This is only used for world-model evaluation currently, PolicyLearner
+      # uses algorithm specific hparams to set this during training.
+      simulated_rollout_length=50,
+
+      # To be overriden
+      base_algo="",
+      base_algo_params="",
+      # Number of real environments to train on simultaneously.
+      real_batch_size=-1,
+      # Number of simulated environments to train on simultaneously.
+      simulated_batch_size=-1,
+      eval_batch_size=-1,
   )
+
+
+def update_hparams(hparams, other):
+  for key, value in six.iteritems(other):
+    if key in hparams.values():
+      hparams.set_hparam(key, value)
+    else:
+      hparams.add_hparam(key, value)
+
+
+@registry.register_hparams
+def rlmb_ppo_base():
+  hparams = _rlmb_base()
+  ppo_params = dict(
+      base_algo="ppo",
+      base_algo_params="ppo_original_params",
+      # Number of real environments to train on simultaneously.
+      real_batch_size=1,
+      # Number of simulated environments to train on simultaneously.
+      simulated_batch_size=16,
+      eval_batch_size=30,
+
+      # Unused; number of PPO epochs is calculated from the real frame limit.
+      real_ppo_epochs_num=0,
+      # Number of frames that can be taken from the simulated environment before
+      # it diverges, used for training the agent.
+
+      ppo_epochs_num=1000,  # This should be enough to see something
+      # Should be equal to simulated_rollout_length.
+      # TODO(koz4k): Uncouple this by outputing done from SimulatedBatchEnv.
+      ppo_epoch_length=hparams.simulated_rollout_length,
+      # Do not eval since simulated batch env does not produce dones
+      ppo_eval_every_epochs=0,
+      ppo_learning_rate=1e-4,  # Will be changed, just so it exists.
+      # This needs to be divisible by real_ppo_effective_num_agents.
+      real_ppo_epoch_length=16 * 200,
+      real_ppo_learning_rate=1e-4,
+      real_ppo_effective_num_agents=16,
+      real_ppo_eval_every_epochs=0,
+  )
+  update_hparams(hparams, ppo_params)
+  return hparams
+
+
+@registry.register_hparams
+def rlmb_base():
+  return rlmb_ppo_base()
 
 
 @registry.register_hparams
@@ -382,38 +416,49 @@ def rlmb_model_only():
   return hp
 
 
+def _rlmb_tiny_overrides():
+  """Parameters to override for tiny setting, excluding agent-related hparams"""
+  return dict(
+      epochs=1,
+      num_real_env_frames=128,
+      model_train_steps=2,
+      max_num_noops=1,
+      eval_max_num_noops=1,
+      generative_model_params="next_frame_tiny",
+      stop_loop_early=True,
+      resize_height_factor=2,
+      resize_width_factor=2,
+      wm_eval_rollout_ratios=[1],
+      env_timesteps_limit=7,
+      simulated_rollout_length=2,
+  )
+
+
+@registry.register_hparams
+def rlmb_ppo_tiny():
+  """Tiny set for testing."""
+  hparams = rlmb_ppo_base()
+  hparams = hparams.override_from_dict(_rlmb_tiny_overrides())
+  update_hparams(hparams, dict(
+      ppo_epochs_num=2,
+      ppo_epoch_length=hparams.simulated_rollout_length,
+      real_ppo_epoch_length=36,
+      real_ppo_effective_num_agents=2,
+      real_batch_size=1,
+      eval_batch_size=1,
+  ))
+  return hparams
+
+
 @registry.register_hparams
 def rlmb_tiny():
-  """Tiny set for testing."""
-  return rlmb_base_sampling().override_from_dict(
-      tf.contrib.training.HParams(
-          epochs=1,
-          num_real_env_frames=128,
-          model_train_steps=2,
-          ppo_epochs_num=2,
-          simulated_batch_size=2,
-          simulated_rollout_length=2,
-          ppo_epoch_length=2,
-          real_batch_size=1,
-          real_ppo_epoch_length=36,
-          real_ppo_effective_num_agents=2,
-          max_num_noops=1,
-          eval_batch_size=1,
-          eval_max_num_noops=1,
-          generative_model_params="next_frame_tiny",
-          stop_loop_early=True,
-          resize_height_factor=2,
-          resize_width_factor=2,
-          game="pong",
-          wm_eval_rollout_ratios=[1],
-          env_timesteps_limit=7,
-      ).values())
+  return rlmb_ppo_tiny()
 
 
 @registry.register_hparams
 def rlmb_tiny_stochastic():
   """Tiny setting with a stochastic next-frame model."""
-  hparams = rlmb_tiny()
+  hparams = rlmb_ppo_tiny()
   hparams.epochs = 1  # Too slow with 2 for regular runs.
   hparams.generative_model = "next_frame_basic_stochastic"
   hparams.generative_model_params = "next_frame_basic_stochastic"
@@ -423,7 +468,7 @@ def rlmb_tiny_stochastic():
 @registry.register_hparams
 def rlmb_tiny_recurrent():
   """Tiny setting with a recurrent next-frame model."""
-  hparams = rlmb_tiny()
+  hparams = rlmb_ppo_tiny()
   hparams.epochs = 1  # Too slow with 2 for regular runs.
   hparams.generative_model = "next_frame_basic_recurrent"
   hparams.generative_model_params = "next_frame_basic_recurrent"
@@ -433,7 +478,7 @@ def rlmb_tiny_recurrent():
 @registry.register_hparams
 def rlmb_tiny_sv2p():
   """Tiny setting with a tiny sv2p model."""
-  hparams = rlmb_tiny()
+  hparams = rlmb_ppo_tiny()
   hparams.generative_model = "next_frame_sv2p"
   hparams.generative_model_params = "next_frame_sv2p_tiny"
   hparams.grayscale = False


### PR DESCRIPTION
Removal of redundant filtering of not finished trajectories. (discussed with original code author) (6b18f44)

Split hparams to ones depending on rl algorithm (ppo/dqn) and not. This is needed because each time someone chages something in tiny or base set (e.g. adds new parameter) errors happen for dqn runs (not pushed to master yet).

