### PR TITLE
Fix transformer_moe model has wrong logic in pre/postprocessing

### DIFF
--- a/tensor2tensor/models/research/transformer_moe.py
+++ b/tensor2tensor/models/research/transformer_moe.py
@@ -93,8 +93,8 @@ class TransformerMoe(t2t_model.T2TModel):
       """Apply processing and capture the extra loss."""
       @expert_utils.add_var_scope()
       def decorated(x, *args, **kwargs):
-        x = dp_preprocess(x)
-        y, loss = fct(x, *args, **kwargs)
+        x_preprocessed = dp_preprocess(x)
+        y, loss = fct(x_preprocessed, *args, **kwargs)
         cache["extra_loss"] += loss
         return dp_postprocess(x, y)
       return decorated


### PR DESCRIPTION
There is a wrong logic in transformer_moe model that make training loss not decrease and make decoding always generate empty output.

By comparing logic with transformer.py and common_attention.py, I found that 'dp_postprocess' should receive input 'x' before passing 'dp_preprocess' in order to have it run with the same logic with transformer model. I changed the logic as in this commit and ran test data to confirm that training loss is decrease and decoding generate correct result.

Unit Testing Result:

Before Fix:
![screenshot from 2018-11-17 15-51-04](https://user-images.githubusercontent.com/11656659/48659251-b351dc00-ea80-11e8-9374-5f221bb94d47.png)

After Fix:
![screenshot from 2018-11-17 15-50-38](https://user-images.githubusercontent.com/11656659/48659255-bc42ad80-ea80-11e8-80d8-03d4fe67fe25.png)

