### PR TITLE
Undefined name: xrange() was removed in Python 3

### DIFF
--- a/tensor2tensor/models/research/vqa_self_attention.py
+++ b/tensor2tensor/models/research/vqa_self_attention.py
@@ -19,6 +19,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
+
 from tensor2tensor.layers import common_attention
 from tensor2tensor.layers import common_hparams
 from tensor2tensor.layers import common_layers


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of a revamped version of __range()__.  This PR proposes adding [__from six.moves import xrange__](https://six.readthedocs.io/#module-six.moves) to ensure equivalent functionality on both Python 2 and Python 3 and to avoid the potential of NameError being raised at runtime on Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/tensorflow/tensor2tensor on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tensor2tensor/models/research/vqa_self_attention.py:658:12: F821 undefined name 'xrange'
  for _ in xrange(hparams.num_rec_steps):
           ^
1    F821 undefined name 'xrange'
1
```