### PR TITLE
Fix problem_0_steps in checkpoint averages

### DIFF
--- a/tensor2tensor/bin/t2t_avg_all.py
+++ b/tensor2tensor/bin/t2t_avg_all.py
@@ -63,7 +63,8 @@ def main(_):
       var_list = tf.contrib.framework.list_variables(model.filename)
       avg_values = {}
       for (name, shape) in var_list:
-        if not name.startswith("global_step"):
+        if not (name.startswith("global_step") or
+                name.startswith("train_stats/")):
           avg_values[name] = np.zeros(shape)
     models_processed += 1
 
@@ -88,6 +89,8 @@ def main(_):
         "global_step",
         initializer=tf.constant(model.steps, dtype=tf.int64),
         trainable=False)
+    with tf.variable_scope("train_stats"):
+      tf.get_variable("problem_0_steps", initializer=0, trainable=False)
     saver = tf.train.Saver(tf.global_variables())
 
     tf.logging.info("Running session for %s" % (out_file))


### PR DESCRIPTION
Currently `t2t-avg-all` creates an average of the `train_stats/problem_0_steps` variable, of type float32, which prevents restoring variables from the averaged checkpoints. This fix will create a dummy `train_stats/problem_0_steps` variable, of type int32.