### PR TITLE
add a metrics for calculating pearson correlation coefficient

### DIFF
--- a/tensor2tensor/utils/metrics.py
+++ b/tensor2tensor/utils/metrics.py
@@ -753,7 +753,7 @@ def pearson_correlation_coefficient(predictions, labels, weights_fn=None):
   Returns:
     The pearson correlation coefficient.
   """
-  pearson = tf.contrib.metrics.streaming_pearson_correlation(predictions, labels)
+  _, pearson = tf.contrib.metrics.streaming_pearson_correlation(predictions, labels)
   return pearson, tf.constant(1.0)
 
 # Metrics are functions that take predictions and labels and return

--- a/tensor2tensor/utils/metrics.py
+++ b/tensor2tensor/utils/metrics.py
@@ -43,6 +43,7 @@ class Metrics(object):
   APPROX_BLEU = "approx_bleu_score"
   RMSE = "rmse"
   LOG_POISSON = "log_poisson"
+  PEARSON = "pearson"
   R2 = "r_squared"
   ROUGE_2_F = "rouge_2_fscore"
   ROUGE_L_F = "rouge_L_fscore"
@@ -100,6 +101,21 @@ def padded_log_poisson(predictions,
 
   lp_loss = tf.nn.log_poisson_loss(targets, predictions, compute_full_loss=True)
   return tf.reduce_sum(lp_loss * weights), tf.reduce_sum(weights)
+
+
+def pearson_correlation_coefficient(predictions, labels, weights_fn=None):
+  """Calculate pearson correlation coefficient.
+
+  Args:
+    predictions: The raw predictions.
+    labels: The actual labels.
+    weights_fn: Weighting function.
+
+  Returns:
+    The pearson correlation coefficient.
+  """
+  pearson = tf.contrib.metrics.streaming_pearson_correlation(predictions, labels)
+  return pearson, tf.constant(1.0)
 
 
 def padded_variance_explained(predictions,
@@ -756,6 +772,7 @@ METRICS_FNS = {
     Metrics.APPROX_BLEU: bleu_hook.bleu_score,
     Metrics.RMSE: padded_rmse,
     Metrics.LOG_POISSON: padded_log_poisson,
+    Metrics.PEARSON: pearson_correlation_coefficient,
     Metrics.R2: padded_variance_explained,
     Metrics.ROUGE_2_F: rouge.rouge_2_fscore,
     Metrics.ROUGE_L_F: rouge.rouge_l_fscore,

--- a/tensor2tensor/utils/metrics.py
+++ b/tensor2tensor/utils/metrics.py
@@ -103,21 +103,6 @@ def padded_log_poisson(predictions,
   return tf.reduce_sum(lp_loss * weights), tf.reduce_sum(weights)
 
 
-def pearson_correlation_coefficient(predictions, labels, weights_fn=None):
-  """Calculate pearson correlation coefficient.
-
-  Args:
-    predictions: The raw predictions.
-    labels: The actual labels.
-    weights_fn: Weighting function.
-
-  Returns:
-    The pearson correlation coefficient.
-  """
-  pearson = tf.contrib.metrics.streaming_pearson_correlation(predictions, labels)
-  return pearson, tf.constant(1.0)
-
-
 def padded_variance_explained(predictions,
                               labels,
                               weights_fn=common_layers.weights_all):
@@ -756,6 +741,20 @@ def word_error_rate(raw_predictions,
 
     return distance / reference_length, reference_length
 
+
+def pearson_correlation_coefficient(predictions, labels, weights_fn=None):
+  """Calculate pearson correlation coefficient.
+
+  Args:
+    predictions: The raw predictions.
+    labels: The actual labels.
+    weights_fn: Weighting function.
+
+  Returns:
+    The pearson correlation coefficient.
+  """
+  pearson = tf.contrib.metrics.streaming_pearson_correlation(predictions, labels)
+  return pearson, tf.constant(1.0)
 
 # Metrics are functions that take predictions and labels and return
 # a tensor of metrics and a tensor of weights.

--- a/tensor2tensor/utils/metrics_test.py
+++ b/tensor2tensor/utils/metrics_test.py
@@ -325,10 +325,14 @@ class MetricsTest(tf.test.TestCase):
     
     expected = np.corrcoef(np.squeeze(predictions), np.squeeze(targets))[0][1]
     with self.test_session() as session:
-      actual, w = session.run(
-          metrics.pearson_correlation_coefficient(
+      pearson, _ = metrics.pearson_correlation_coefficient(
               tf.constant(predictions, dtype=tf.float32), 
-              tf.constant(targets, dtype=tf.float32)))
+              tf.constant(targets, dtype=tf.float32))
+      session.run(tf.global_variables_initializer())
+      session.run(tf.local_variables_initializer())
+      actual = session.run(pearson)
+    print(actual)
+    print(expected)
     self.assertAlmostEqual(actual, expected)
 
 if __name__ == '__main__':

--- a/tensor2tensor/utils/metrics_test.py
+++ b/tensor2tensor/utils/metrics_test.py
@@ -319,6 +319,19 @@ class MetricsTest(tf.test.TestCase):
       actual = session.run(a)
     self.assertAlmostEqual(actual, expected, places=6)
 
+  def testPearsonCorrelationCoefficient(self):
+    predictions = np.random.randint(4, size=(12, 12, 12, 1))
+    targets = np.random.randint(4, size=(12, 12, 12, 1))
+    
+    expected = np.corrcoef(np.squeeze(predictions), np.squeeze(targets))[0, 1]
+    with self.test_session() as session:
+      pearson, _ = metrics.pearson_correlation_coefficient(
+          tf.one_hot(predictions, depth=4, dtype=tf.float32),
+          tf.constant(targets, dtype=tf.int32))
+      a = tf.reduce_mean(pearson)
+      session.run(tf.global_variables_initializer())
+      actual = session.run(a)
+    self.assertAlmostEqual(actual, expected)
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensor2tensor/utils/metrics_test.py
+++ b/tensor2tensor/utils/metrics_test.py
@@ -325,7 +325,9 @@ class MetricsTest(tf.test.TestCase):
     
     expected = np.corrcoef(np.squeeze(predictions), np.squeeze(targets))[0][1]
     with self.test_session() as session:
-      pearson, _ = metrics.pearson_correlation_coefficient(predictions, targets)
+      pearson, _ = metrics.pearson_correlation_coefficient(
+          tf.constant(predictions, dtype=tf.float32), 
+          tf.constant(targets, dtype=tf.float32))
       a = tf.reduce_mean(pearson)
       session.run(tf.global_variables_initializer())
       actual = session.run(a)

--- a/tensor2tensor/utils/metrics_test.py
+++ b/tensor2tensor/utils/metrics_test.py
@@ -320,8 +320,8 @@ class MetricsTest(tf.test.TestCase):
     self.assertAlmostEqual(actual, expected, places=6)
 
   def testPearsonCorrelationCoefficient(self):
-    predictions = np.random.randint(4, size=(12, 1))
-    targets = np.random.randint(4, size=(12, 1))
+    predictions = np.random.rand(12, 1)
+    targets = np.random.rand(12, 1)
     
     expected = np.corrcoef(np.squeeze(predictions), np.squeeze(targets))[0][1]
     with self.test_session() as session:

--- a/tensor2tensor/utils/metrics_test.py
+++ b/tensor2tensor/utils/metrics_test.py
@@ -320,8 +320,8 @@ class MetricsTest(tf.test.TestCase):
     self.assertAlmostEqual(actual, expected, places=6)
 
   def testPearsonCorrelationCoefficient(self):
-    predictions = np.random.randint(4, size=(12, 12, 12, 1))
-    targets = np.random.randint(4, size=(12, 12, 12, 1))
+    predictions = np.random.randint(4, size=(12, 1))
+    targets = np.random.randint(4, size=(12, 1))
     
     expected = np.corrcoef(np.squeeze(predictions), np.squeeze(targets))[0, 1]
     with self.test_session() as session:

--- a/tensor2tensor/utils/metrics_test.py
+++ b/tensor2tensor/utils/metrics_test.py
@@ -326,7 +326,7 @@ class MetricsTest(tf.test.TestCase):
     expected = np.corrcoef(np.squeeze(predictions), np.squeeze(targets))[0, 1]
     with self.test_session() as session:
       pearson, _ = metrics.pearson_correlation_coefficient(
-          tf.one_hot(predictions, depth=4, dtype=tf.float32),
+          tf.one_hot(predictions, depth=2, dtype=tf.float32),
           tf.constant(targets, dtype=tf.int32))
       a = tf.reduce_mean(pearson)
       session.run(tf.global_variables_initializer())

--- a/tensor2tensor/utils/metrics_test.py
+++ b/tensor2tensor/utils/metrics_test.py
@@ -325,12 +325,10 @@ class MetricsTest(tf.test.TestCase):
     
     expected = np.corrcoef(np.squeeze(predictions), np.squeeze(targets))[0][1]
     with self.test_session() as session:
-      pearson, _ = metrics.pearson_correlation_coefficient(
-          tf.constant(predictions, dtype=tf.float32), 
-          tf.constant(targets, dtype=tf.float32))
-      a = tf.reduce_mean(pearson)
-      session.run(tf.global_variables_initializer())
-      actual = session.run(a)
+      actual, w = session.run(
+          metrics.pearson_correlation_coefficient(
+              tf.constant(predictions, dtype=tf.float32), 
+              tf.constant(targets, dtype=tf.float32)))
     self.assertAlmostEqual(actual, expected)
 
 if __name__ == '__main__':

--- a/tensor2tensor/utils/metrics_test.py
+++ b/tensor2tensor/utils/metrics_test.py
@@ -323,11 +323,9 @@ class MetricsTest(tf.test.TestCase):
     predictions = np.random.randint(4, size=(12, 1))
     targets = np.random.randint(4, size=(12, 1))
     
-    expected = np.corrcoef(np.squeeze(predictions), np.squeeze(targets))[0, 1]
+    expected = np.corrcoef(np.squeeze(predictions), np.squeeze(targets))[0][1]
     with self.test_session() as session:
-      pearson, _ = metrics.pearson_correlation_coefficient(
-          tf.one_hot(predictions, depth=2, dtype=tf.float32),
-          tf.constant(targets, dtype=tf.int32))
+      pearson, _ = metrics.pearson_correlation_coefficient(predictions, targets)
       a = tf.reduce_mean(pearson)
       session.run(tf.global_variables_initializer())
       actual = session.run(a)


### PR DESCRIPTION
Dear community, I'm using tensor2tensor for text similarity tasks and I find no metrics for calculating pearson correlation coefficient.