### PR TITLE
MRPC: Exclude dev data from training dataset

### DIFF
--- a/tensor2tensor/data_generators/mrpc.py
+++ b/tensor2tensor/data_generators/mrpc.py
@@ -58,6 +58,9 @@ class MSRParaphraseCorpus(text_problems.TextConcat2ClassProblem):
     }, {
         "split": problem.DatasetSplit.EVAL,
         "shards": 1,
+    }, {
+        "split": problem.DatasetSplit.TEST,
+        "shards": 1,
     }]
 
   @property
@@ -89,7 +92,7 @@ class MSRParaphraseCorpus(text_problems.TextConcat2ClassProblem):
 
     return mrpc_dir
 
-  def example_generator(self, filename, dev_ids):
+  def example_generator(self, filename, dev_ids, dataset_split):
     for idx, line in enumerate(tf.gfile.Open(filename, "rb")):
       if idx == 0: continue  # skip header
       if six.PY2:
@@ -97,7 +100,10 @@ class MSRParaphraseCorpus(text_problems.TextConcat2ClassProblem):
       else:
         line = line.strip().decode("utf-8")
       l, id1, id2, s1, s2 = line.split("\t")
-      if dev_ids and [id1, id2] not in dev_ids:
+      is_dev = [id1, id2] in dev_ids
+      if dataset_split == problem.DatasetSplit.TRAIN and is_dev:
+        continue
+      if dataset_split == problem.DatasetSplit.EVAL and not is_dev:
         continue
       inputs = [[s1, s2], [s2, s1]]
       for inp in inputs:
@@ -108,14 +114,17 @@ class MSRParaphraseCorpus(text_problems.TextConcat2ClassProblem):
 
   def generate_samples(self, data_dir, tmp_dir, dataset_split):
     mrpc_dir = self._maybe_download_corpora(tmp_dir)
-    filesplit = "msr_paraphrase_train.txt"
+    if dataset_split != problem.DatasetSplit.TEST:
+      filesplit = "msr_paraphrase_train.txt"
+    else:
+      filesplit = "msr_paraphrase_test.txt"
     dev_ids = []
-    if dataset_split != problem.DatasetSplit.TRAIN:
+    if dataset_split != problem.DatasetSplit.TEST:
       for row in tf.gfile.Open(os.path.join(mrpc_dir, "dev_ids.tsv")):
         dev_ids.append(row.strip().split("\t"))
 
     filename = os.path.join(mrpc_dir, filesplit)
-    for example in self.example_generator(filename, dev_ids):
+    for example in self.example_generator(filename, dev_ids, dataset_split):
       yield example
 
 


### PR DESCRIPTION
Fixes #1280 

### Short description of what this PR does:

- Exclude dev data from training dataset of MRPC
- Add MRPC test dataset

#### The number of examples before this PR:
- Training: 8152
- Dev: 816
- Test: 0

#### The number of examples after this PR:
- Training: 7336
- Dev: 816
- Test: 3450