### PR TITLE
Add Fast Decoding  Support For Relative Dot Product

### DIFF
--- a/tensor2tensor/models/transformer.py
+++ b/tensor2tensor/models/transformer.py
@@ -273,7 +273,7 @@ class Transformer(t2t_model.T2TModel):
               None if using greedy decoding (beam_size=1)
       }
     """
-    if self._hparams.self_attention_type != "dot_product":
+    if self._hparams.self_attention_type not in ["dot_product", "dot_product_relative1"]:
       # Caching is not guaranteed to work with attention types other than
       # dot_product.
       # TODO(petershaw): Support fast decoding when using relative


### PR DESCRIPTION
Add Fast Decoding  Support For And Only For Relative Dot Product by enabling caching mechanism.
This pr have been tested on "En-Zh" case and got the same results as expected.