### PR TITLE
Enable Relative Dot Product Visualization

### DIFF
--- a/tensor2tensor/models/transformer.py
+++ b/tensor2tensor/models/transformer.py
@@ -273,7 +273,7 @@ class Transformer(t2t_model.T2TModel):
               None if using greedy decoding (beam_size=1)
       }
     """
-    if self._hparams.self_attention_type != "dot_product":
+    if self._hparams.self_attention_type not in ["dot_product", "dot_product_relative1"]:
       # Caching is not guaranteed to work with attention types other than
       # dot_product.
       # TODO(petershaw): Support fast decoding when using relative

--- a/tensor2tensor/models/transformer.py
+++ b/tensor2tensor/models/transformer.py
@@ -273,7 +273,7 @@ class Transformer(t2t_model.T2TModel):
               None if using greedy decoding (beam_size=1)
       }
     """
-    if self._hparams.self_attention_type not in ["dot_product", "dot_product_relative1"]:
+    if self._hparams.self_attention_type not in ["dot_product", "dot_product_relative"]:
       # Caching is not guaranteed to work with attention types other than
       # dot_product.
       # TODO(petershaw): Support fast decoding when using relative

--- a/tensor2tensor/visualization/visualization.py
+++ b/tensor2tensor/visualization/visualization.py
@@ -183,15 +183,19 @@ def get_att_mats(translate_model):
   encdec_atts = []
 
   prefix = 'transformer/body/'
-  postfix = '/multihead_attention/dot_product_attention'
+  if translate_model.hparams.self_attention_type != "dot_product_relative":
+    postfix_self_attention = '/multihead_attention/dot_product_attention'
+  else:
+    postfix_self_attention = '/multihead_attention/dot_product_attention_relative'
+  postfix_encdec = '/multihead_attention/dot_product_attention'
 
   for i in range(translate_model.hparams.num_hidden_layers):
     enc_att = translate_model.attention_weights[
-        '%sencoder/layer_%i/self_attention%s' % (prefix, i, postfix)]
+        '%sencoder/layer_%i/self_attention%s' % (prefix, i, postfix_self_attention)]
     dec_att = translate_model.attention_weights[
-        '%sdecoder/layer_%i/self_attention%s' % (prefix, i, postfix)]
+        '%sdecoder/layer_%i/self_attention%s' % (prefix, i, postfix_self_attention)]
     encdec_att = translate_model.attention_weights[
-        '%sdecoder/layer_%i/encdec_attention%s' % (prefix, i, postfix)]
+        '%sdecoder/layer_%i/encdec_attention%s' % (prefix, i, postfix_encdec)]
     enc_atts.append(enc_att)
     dec_atts.append(dec_att)
     encdec_atts.append(encdec_att)

--- a/tensor2tensor/visualization/visualization.py
+++ b/tensor2tensor/visualization/visualization.py
@@ -183,9 +183,8 @@ def get_att_mats(translate_model):
   encdec_atts = []
 
   prefix = 'transformer/body/'
-  if translate_model.hparams.self_attention_type != "dot_product_relative":
-    postfix_self_attention = '/multihead_attention/dot_product_attention'
-  else:
+  postfix_self_attention = '/multihead_attention/dot_product_attention'
+  if translate_model.hparams.self_attention_type == "dot_product_relative":
     postfix_self_attention = '/multihead_attention/dot_product_attention_relative'
   postfix_encdec = '/multihead_attention/dot_product_attention'
 


### PR DESCRIPTION
Hi, I've got some  further works on `dot_product_relative` here.

This PR enables visualization of `self-attention` and `encdec-attention` when using `dot_product_relative` as `self-attention` type