### PR TITLE
Fix bug: "is_generate_per_split" should be set to property.

### DIFF
--- a/tensor2tensor/data_generators/translate.py
+++ b/tensor2tensor/data_generators/translate.py
@@ -36,6 +36,7 @@ FLAGS = tf.flags.FLAGS
 class TranslateProblem(text_problems.Text2TextProblem):
   """Base class for translation problems."""
 
+  @property
   def is_generate_per_split(self):
     return True
 


### PR DESCRIPTION
`is_generate_per_split` in TranslateProblem inherits from Text2TextProblem, so it should be set to property. Otherwise when we train model of TranslateProblem, the judgement in https://github.com/tensorflow/tensor2tensor/blob/65f66e70a1b145398e2df3c35f5af5fb135c7467/tensor2tensor/data_generators/text_problems.py#L302 will always be true (self.is_generate_per_split returns a method object), even if we overwrite `is_generate_per_split` (without `@property`) to return `False` in the subclass of TranslateProblem.