### PR TITLE
In the models/transformer.py, a model called Transformer Encoder was created .

### DIFF
--- a/tensor2tensor/models/transformer.py
+++ b/tensor2tensor/models/transformer.py
@@ -1121,6 +1121,22 @@ class TransformerEncoder(t2t_model.T2TModel):
 
     return encoder_output
 
+@registry.register_model
+class TransformerRegressor(transformer.TransformerEncoder):
+  """Transformer inheriting from Encoder, for the regression problem.
+  Final res is a tensor that has a shape of (?, 1, 1, 1)
+  """
+
+  def top(self, body_output, features):
+    """Computes single scalar value from body_output
+    """
+    with tf.variable_scope("reg_top_ffn"):
+      # scalar = common_layers.dense(body_output,hparams)
+      x = body_output
+      x = tf.reduce_mean(x, axis=[1, 2], keepdims=True)
+      res = tf.layers.dense(x, 1, name="model_top")
+      return res
+
 
 def features_to_nonpadding(features, inputs_or_targets="inputs"):
   key = inputs_or_targets + "_segmentation"


### PR DESCRIPTION
A new class called Transformer Regressor was created in the models/transformer.py in order to conduct a regression method such as sentiment analysis. 
This is done by inheriting from Transformer Encoder and this is supposed to produce a real number as an output tensor with the shape of (N, 1,1,1) from input tensor.
