### PR TITLE
Upgrade Cloud ML version to tf@1.12

### DIFF
--- a/tensor2tensor/utils/cloud_mlengine.py
+++ b/tensor2tensor/utils/cloud_mlengine.py
@@ -34,14 +34,14 @@ import tensorflow as tf
 FLAGS = tf.flags.FLAGS
 
 CONSOLE_URL = "https://console.cloud.google.com/mlengine/jobs/"
-RUNTIME_VERSION = "1.9"
+RUNTIME_VERSION = "1.12"
 
 
 class Gcloud(object):
   """gcloud command strings."""
   # Note these can be modified by set_versions
-  VM_VERSION = "tf-1-9"
-  TPU_VERSION = "1.9"
+  VM_VERSION = "tf-1-12"
+  TPU_VERSION = "1.12"
 
   @classmethod
   def set_versions(cls, vm, tpu):


### PR DESCRIPTION
`tensor2tensor` requires [`tensorflow>=1.12.0`](https://github.com/tensorflow/tensor2tensor/blob/master/setup.py#L59).
This PR upgrades the version on Cloud ML to 1.12 in order to fix run time errors.

Fixes #1234
Note: I only tested this change on Cloud ML *without* a TPU.