### PR TITLE
Replace deprecated np.random.random_integers with np.random.randint

### DIFF
--- a/tensor2tensor/layers/common_layers_test.py
+++ b/tensor2tensor/layers/common_layers_test.py
@@ -48,7 +48,7 @@ class CommonLayersTest(parameterized.TestCase, tf.test.TestCase):
 
   @tf.contrib.eager.run_test_in_graph_and_eager_modes()
   def testFlatten4D3D(self):
-    x = np.random.random_integers(1, high=8, size=(3, 5, 2))
+    x = np.random.randint(1, high=9, size=(3, 5, 2))
     y = common_layers.flatten4d3d(common_layers.embedding(x, 10, 7))
     self.evaluate(tf.global_variables_initializer())
     res = self.evaluate(y)
@@ -56,7 +56,7 @@ class CommonLayersTest(parameterized.TestCase, tf.test.TestCase):
 
   @tf.contrib.eager.run_test_in_graph_and_eager_modes()
   def testEmbedding(self):
-    x = np.random.random_integers(1, high=8, size=(3, 5))
+    x = np.random.randint(1, high=9, size=(3, 5))
     y = common_layers.embedding(x, 10, 16)
     self.evaluate(tf.global_variables_initializer())
     res = self.evaluate(y)

--- a/tensor2tensor/layers/modalities_test.py
+++ b/tensor2tensor/layers/modalities_test.py
@@ -39,7 +39,7 @@ class ModalityTest(tf.test.TestCase):
     model_hparams = common_hparams.basic_params1()
     model_hparams.hidden_size = hidden_size
     model_hparams.mode = tf.estimator.ModeKeys.TRAIN
-    x = -1 + np.random.random_integers(
+    x = np.random.randint(
         vocab_size, size=(batch_size, length, 1, 1))
     m = modalities.SymbolModality(model_hparams, vocab_size)
     data_parallelism = expert_utils.Parallelism(
@@ -62,9 +62,9 @@ class ModalityTest(tf.test.TestCase):
     model_hparams = common_hparams.basic_params1()
     model_hparams.hidden_size = hidden_size
     model_hparams.mode = tf.estimator.ModeKeys.TRAIN
-    body_output = -1 + np.random.random_integers(
+    body_output = np.random.randint(
         100, size=(batch_size, length, height, hidden_size))
-    targets = -1 + np.random.random_integers(
+    targets = np.random.randint(
         vocab_size, size=(batch_size, length, height, 1))
     m = modalities.SymbolModality(model_hparams, vocab_size)
     data_parallelism = expert_utils.Parallelism(
@@ -92,9 +92,9 @@ class ModalityTest(tf.test.TestCase):
     model_hparams.factored_logits = True
     model_hparams.hidden_size = hidden_size
     model_hparams.mode = tf.estimator.ModeKeys.TRAIN
-    body_output = -1 + np.random.random_integers(
+    body_output = np.random.randint(
         100, size=(batch_size, length, height, hidden_size))
-    targets = -1 + np.random.random_integers(
+    targets = np.random.randint(
         vocab_size, size=(batch_size, length, height, 1))
     m = modalities.SymbolModality(model_hparams, vocab_size)
     data_parallelism = expert_utils.Parallelism(

--- a/tensor2tensor/models/basic_test.py
+++ b/tensor2tensor/models/basic_test.py
@@ -30,8 +30,8 @@ import tensorflow as tf
 class BasicTest(tf.test.TestCase):
 
   def testBasicFcRelu(self):
-    x = np.random.random_integers(0, high=255, size=(1, 28, 28, 1))
-    y = np.random.random_integers(0, high=9, size=(1, 1))
+    x = np.random.randint(256, size=(1, 28, 28, 1))
+    y = np.random.randint(10, size=(1, 1))
     hparams = trainer_lib.create_hparams(
         "basic_fc_small", problem_name="image_mnist", data_dir=".")
     with self.test_session() as session:

--- a/tensor2tensor/models/bytenet_test.py
+++ b/tensor2tensor/models/bytenet_test.py
@@ -30,8 +30,8 @@ class ByteNetTest(tf.test.TestCase):
 
   def testByteNet(self):
     vocab_size = 9
-    x = np.random.random_integers(1, high=vocab_size - 1, size=(3, 5, 1, 1))
-    y = np.random.random_integers(1, high=vocab_size - 1, size=(3, 6, 1, 1))
+    x = np.random.randint(1, high=vocab_size, size=(3, 5, 1, 1))
+    y = np.random.randint(1, high=vocab_size, size=(3, 6, 1, 1))
     hparams = bytenet.bytenet_base()
     p_hparams = problem_hparams.test_problem_hparams(vocab_size,
                                                      vocab_size,

--- a/tensor2tensor/models/image_transformer_2d_test.py
+++ b/tensor2tensor/models/image_transformer_2d_test.py
@@ -35,8 +35,8 @@ class Img2imgTransformerTest(tf.test.TestCase):
     hparams = image_transformer_2d.img2img_transformer2d_tiny()
     hparams.data_dir = ""
     p_hparams = registry.problem("image_celeba").get_hparams(hparams)
-    inputs = np.random.random_integers(0, high=255, size=(3, 4, 4, 3))
-    targets = np.random.random_integers(0, high=255, size=(3, 8, 8, 3))
+    inputs = np.random.randint(256, size=(3, 4, 4, 3))
+    targets = np.random.randint(256, size=(3, 8, 8, 3))
     with self.test_session() as session:
       features = {
           "inputs": tf.constant(inputs, dtype=tf.int32),
@@ -63,9 +63,9 @@ class Imagetransformer2dTest(tf.test.TestCase):
     p_hparams = problem_hparams.test_problem_hparams(vocab_size,
                                                      vocab_size,
                                                      hparams)
-    inputs = -1 + np.random.random_integers(
+    inputs = np.random.randint(
         vocab_size, size=(batch_size, 1, 1, 1))
-    targets = -1 + np.random.random_integers(
+    targets = np.random.randint(
         vocab_size, size=(batch_size, size, size, 3))
     with self.test_session() as session:
       features = {

--- a/tensor2tensor/models/image_transformer_test.py
+++ b/tensor2tensor/models/image_transformer_test.py
@@ -46,9 +46,9 @@ class ImagetransformerTest(parameterized.TestCase, tf.test.TestCase):
     p_hparams = problem_hparams.test_problem_hparams(vocab_size,
                                                      vocab_size,
                                                      hparams)
-    inputs = -1 + np.random.random_integers(
+    inputs = np.random.randint(
         vocab_size, size=(batch_size, 1, 1, 1))
-    targets = -1 + np.random.random_integers(
+    targets = np.random.randint(
         vocab_size, size=(batch_size, size, size, 3))
     with self.test_session() as session:
       features = {

--- a/tensor2tensor/models/lstm_test.py
+++ b/tensor2tensor/models/lstm_test.py
@@ -30,8 +30,8 @@ class LSTMTest(tf.test.TestCase):
 
   def testLSTMSeq2Seq(self):
     vocab_size = 9
-    x = np.random.random_integers(1, high=vocab_size - 1, size=(3, 5, 1, 1))
-    y = np.random.random_integers(1, high=vocab_size - 1, size=(3, 6, 1, 1))
+    x = np.random.randint(1, high=vocab_size, size=(3, 5, 1, 1))
+    y = np.random.randint(1, high=vocab_size, size=(3, 6, 1, 1))
     hparams = lstm.lstm_seq2seq()
     p_hparams = problem_hparams.test_problem_hparams(vocab_size,
                                                      vocab_size,
@@ -50,8 +50,8 @@ class LSTMTest(tf.test.TestCase):
 
   def testLSTMSeq2SeqAttention(self):
     vocab_size = 9
-    x = np.random.random_integers(1, high=vocab_size - 1, size=(3, 5, 1, 1))
-    y = np.random.random_integers(1, high=vocab_size - 1, size=(3, 6, 1, 1))
+    x = np.random.randint(1, high=vocab_size, size=(3, 5, 1, 1))
+    y = np.random.randint(1, high=vocab_size, size=(3, 6, 1, 1))
     hparams = lstm.lstm_attention()
 
     p_hparams = problem_hparams.test_problem_hparams(vocab_size,
@@ -74,8 +74,8 @@ class LSTMTest(tf.test.TestCase):
 
   def testLSTMSeq2seqBidirectionalEncoder(self):
     vocab_size = 9
-    x = np.random.random_integers(1, high=vocab_size - 1, size=(3, 5, 1, 1))
-    y = np.random.random_integers(1, high=vocab_size - 1, size=(3, 6, 1, 1))
+    x = np.random.randint(1, high=vocab_size, size=(3, 5, 1, 1))
+    y = np.random.randint(1, high=vocab_size, size=(3, 6, 1, 1))
     hparams = lstm.lstm_seq2seq()
     p_hparams = problem_hparams.test_problem_hparams(vocab_size,
                                                      vocab_size,
@@ -94,8 +94,8 @@ class LSTMTest(tf.test.TestCase):
 
   def testLSTMSeq2seqAttentionBidirectionalEncoder(self):
     vocab_size = 9
-    x = np.random.random_integers(1, high=vocab_size - 1, size=(3, 5, 1, 1))
-    y = np.random.random_integers(1, high=vocab_size - 1, size=(3, 6, 1, 1))
+    x = np.random.randint(1, high=vocab_size, size=(3, 5, 1, 1))
+    y = np.random.randint(1, high=vocab_size, size=(3, 6, 1, 1))
     hparams = lstm.lstm_attention()
 
     p_hparams = problem_hparams.test_problem_hparams(vocab_size, vocab_size)

--- a/tensor2tensor/models/mtf_image_transformer_test.py
+++ b/tensor2tensor/models/mtf_image_transformer_test.py
@@ -49,7 +49,7 @@ def get_model(hparams=None,
   del p_hparams.modality["inputs"]
   hparams.problem_hparams = p_hparams
 
-  targets = -1 + np.random.random_integers(
+  targets = np.random.randint(
       VOCAB_SIZE, size=(BATCH_SIZE, IMG_LENGTH, IMG_LENGTH, 1, 1))
   features = {
       "targets": tf.constant(targets, dtype=tf.int32, name="targets"),

--- a/tensor2tensor/models/mtf_transformer_test.py
+++ b/tensor2tensor/models/mtf_transformer_test.py
@@ -48,9 +48,9 @@ def get_model(hparams=None, mode=tf.estimator.ModeKeys.TRAIN,
     del p_hparams.modality["inputs"]
   hparams.problem_hparams = p_hparams
 
-  inputs = -1 + np.random.random_integers(
+  inputs = np.random.randint(
       VOCAB_SIZE, size=(BATCH_SIZE, INPUT_LENGTH, 1, 1))
-  targets = -1 + np.random.random_integers(
+  targets = np.random.randint(
       VOCAB_SIZE, size=(BATCH_SIZE, TARGET_LENGTH, 1, 1))
   features = {
       "targets": tf.constant(targets, dtype=tf.int32, name="targets"),

--- a/tensor2tensor/models/neural_gpu_test.py
+++ b/tensor2tensor/models/neural_gpu_test.py
@@ -39,9 +39,9 @@ class NeuralGPUTest(tf.test.TestCase):
     p_hparams = problem_hparams.test_problem_hparams(input_vocab_size,
                                                      target_vocab_size,
                                                      hparams)
-    inputs = -1 + np.random.random_integers(
+    inputs = np.random.randint(
         input_vocab_size, size=(batch_size, input_length, 1, 1))
-    targets = -1 + np.random.random_integers(
+    targets = np.random.randint(
         target_vocab_size, size=(batch_size, target_length, 1, 1))
     with self.test_session() as session:
       features = {

--- a/tensor2tensor/models/research/autoencoders_test.py
+++ b/tensor2tensor/models/research/autoencoders_test.py
@@ -33,8 +33,8 @@ class AutoencoderTest(tf.test.TestCase):
   def get_mnist_random_output(self, model_name, hparams_set=None,
                               mode=tf.estimator.ModeKeys.TRAIN):
     hparams_set = hparams_set or model_name
-    x = np.random.random_integers(0, high=255, size=(1, 28, 28, 1))
-    y = np.random.random_integers(0, high=9, size=(1, 1))
+    x = np.random.randint(256, size=(1, 28, 28, 1))
+    y = np.random.randint(10, size=(1, 1))
     features = {
         "targets": tf.constant(x, dtype=tf.int32),
         "inputs": tf.constant(y, dtype=tf.int32),

--- a/tensor2tensor/models/research/gene_expression_test.py
+++ b/tensor2tensor/models/research/gene_expression_test.py
@@ -42,8 +42,8 @@ class GeneExpressionModelsTest(tf.test.TestCase):
     input_length = target_length * 128 // 4  # chunk_size=4
     input_vocab_size = 5
 
-    inputs = np.random.random_integers(
-        input_vocab_size, size=(batch_size, input_length, 1, 1))
+    inputs = np.random.randint(
+        1, input_vocab_size + 1, size=(batch_size, input_length, 1, 1))
     targets = np.random.random_sample((batch_size, target_length, 1,
                                        target_out))
 

--- a/tensor2tensor/models/research/transformer_aux_test.py
+++ b/tensor2tensor/models/research/transformer_aux_test.py
@@ -90,9 +90,9 @@ class TransformerAuxTest(parameterized.TestCase, tf.test.TestCase):
                                                      vocab_size,
                                                      hparams)
     hparams.problem_hparams = p_hparams
-    inputs = -1 + np.random.random_integers(
+    inputs = np.random.randint(
         vocab_size, size=(batch_size, input_length, 1, 1))
-    targets = -1 + np.random.random_integers(
+    targets = np.random.randint(
         vocab_size, size=(batch_size, target_length, 1, 1))
     features = {
         "inputs": tf.constant(inputs, dtype=tf.int32),

--- a/tensor2tensor/models/research/transformer_revnet_test.py
+++ b/tensor2tensor/models/research/transformer_revnet_test.py
@@ -47,9 +47,9 @@ class TransformerRevnetTest(tf.test.TestCase):
                                                      vocab_size,
                                                      hparams)
     hparams.problem_hparams = p_hparams
-    inputs = -1 + np.random.random_integers(
+    inputs = np.random.randint(
         vocab_size, size=(batch_size, input_length, 1, 1))
-    targets = -1 + np.random.random_integers(
+    targets = np.random.randint(
         vocab_size, size=(batch_size, target_length, 1, 1))
     features = {
         "inputs": tf.constant(inputs, dtype=tf.int32),

--- a/tensor2tensor/models/research/transformer_vae_test.py
+++ b/tensor2tensor/models/research/transformer_vae_test.py
@@ -37,9 +37,9 @@ class TransformerVaeTest(tf.test.TestCase):
                                                      vocab_size,
                                                      hparams)
     hparams.problem_hparams = p_hparams
-    inputs = -1 + np.random.random_integers(
+    inputs = np.random.randint(
         vocab_size, size=(batch_size, input_length, 1, 1))
-    targets = -1 + np.random.random_integers(
+    targets = np.random.randint(
         vocab_size, size=(batch_size, target_length, 1, 1))
     features = {
         "inputs": tf.constant(inputs, dtype=tf.int32),

--- a/tensor2tensor/models/research/universal_transformer_test.py
+++ b/tensor2tensor/models/research/universal_transformer_test.py
@@ -48,9 +48,9 @@ class UniversalTransformerTest(tf.test.TestCase):
       del p_hparams.modality["inputs"]
     hparams.problems = [p_hparams]
 
-    inputs = -1 + np.random.random_integers(
+    inputs = np.random.randint(
         VOCAB_SIZE, size=(BATCH_SIZE, INPUT_LENGTH, 1, 1))
-    targets = -1 + np.random.random_integers(
+    targets = np.random.randint(
         VOCAB_SIZE, size=(BATCH_SIZE, TARGET_LENGTH, 1, 1))
     features = {
         "targets": tf.constant(targets, dtype=tf.int32, name="targets"),

--- a/tensor2tensor/models/research/vqa_attention_test.py
+++ b/tensor2tensor/models/research/vqa_attention_test.py
@@ -39,10 +39,10 @@ class VqaAttentionBaselineTest(tf.test.TestCase):
     question_length = 5
     answer_length = 10
     x = 2 * np.random.rand(batch_size, image_size, image_size, 3) - 1
-    q = np.random.random_integers(
-        1, high=vocab_size - 1, size=(batch_size, question_length, 1, 1))
-    a = np.random.random_integers(
-        0, high=num_classes, size=(batch_size, answer_length, 1, 1))
+    q = np.random.randint(
+        1, high=vocab_size, size=(batch_size, question_length, 1, 1))
+    a = np.random.randint(
+        num_classes + 1, size=(batch_size, answer_length, 1, 1))
     hparams = vqa_attention.vqa_attention_base()
     p_hparams = problem_hparams.test_problem_hparams(vocab_size,
                                                      vocab_size,

--- a/tensor2tensor/models/resnet_test.py
+++ b/tensor2tensor/models/resnet_test.py
@@ -40,10 +40,10 @@ class ResnetTest(tf.test.TestCase):
   def _test_resnet(self, img_size, output_size):
     vocab_size = 9
     batch_size = 2
-    x = np.random.random_integers(
-        0, high=255, size=(batch_size, img_size, img_size, 3))
-    y = np.random.random_integers(
-        1, high=vocab_size - 1, size=(batch_size, 1, 1, 1))
+    x = np.random.randint(
+        256, size=(batch_size, img_size, img_size, 3))
+    y = np.random.randint(
+        1, high=vocab_size, size=(batch_size, 1, 1, 1))
     hparams = resnet_tiny_cpu()
     p_hparams = problem_hparams.test_problem_hparams(vocab_size,
                                                      vocab_size,

--- a/tensor2tensor/models/slicenet_test.py
+++ b/tensor2tensor/models/slicenet_test.py
@@ -31,8 +31,8 @@ import tensorflow as tf
 class SliceNetTest(tf.test.TestCase):
 
   def testSliceNet(self):
-    x = np.random.random_integers(0, high=255, size=(3, 5, 5, 3))
-    y = np.random.random_integers(0, high=9, size=(3, 5, 1, 1))
+    x = np.random.randint(256, size=(3, 5, 5, 3))
+    y = np.random.randint(10, size=(3, 5, 1, 1))
     hparams = slicenet.slicenet_params1_tiny()
     hparams.add_hparam("data_dir", "")
     problem = registry.problem("image_cifar10")

--- a/tensor2tensor/models/transformer_test.py
+++ b/tensor2tensor/models/transformer_test.py
@@ -48,9 +48,9 @@ def get_model(hparams=None, mode=tf.estimator.ModeKeys.TRAIN,
     del p_hparams.modality["inputs"]
   hparams.problem_hparams = p_hparams
 
-  inputs = -1 + np.random.random_integers(
+  inputs = np.random.randint(
       VOCAB_SIZE, size=(BATCH_SIZE, INPUT_LENGTH, 1, 1))
-  targets = -1 + np.random.random_integers(
+  targets = np.random.randint(
       VOCAB_SIZE, size=(BATCH_SIZE, TARGET_LENGTH, 1, 1))
   features = {
       "targets": tf.constant(targets, dtype=tf.int32, name="targets"),

--- a/tensor2tensor/models/xception_test.py
+++ b/tensor2tensor/models/xception_test.py
@@ -33,10 +33,10 @@ class XceptionTest(tf.test.TestCase):
   def _test_xception(self, img_size):
     vocab_size = 9
     batch_size = 3
-    x = np.random.random_integers(
-        0, high=255, size=(batch_size, img_size, img_size, 3))
-    y = np.random.random_integers(
-        1, high=vocab_size - 1, size=(batch_size, 1, 1, 1))
+    x = np.random.randint(
+        256, size=(batch_size, img_size, img_size, 3))
+    y = np.random.randint(
+        1, high=vocab_size, size=(batch_size, 1, 1, 1))
     hparams = xception.xception_tiny()
     p_hparams = problem_hparams.test_problem_hparams(vocab_size,
                                                      vocab_size,


### PR DESCRIPTION
[`np.random.random_integers`](https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.random.random_integers.html) is deprecated in favor of [`np.random.randint`](https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.random.randint.html#numpy.random.randint) since numpy version 1.10.

This PR replaces calls to  `np.random.random_integers` with `np.random.randint`.