### PR TITLE
Fix tf.py_func typo

### DIFF
--- a/tensor2tensor/utils/sari_hook.py
+++ b/tensor2tensor/utils/sari_hook.py
@@ -214,7 +214,7 @@ def get_sari(source_ids, prediction_ids, target_ids, max_gram_size=4):
     return (np.asarray(sari_scores), np.asarray(keep_scores),
             np.asarray(add_scores), np.asarray(deletion_scores))
 
-  sari, keep, add, deletion = tf.py_function(
+  sari, keep, add, deletion = tf.py_func(
       get_sari_numpy,
       [source_ids, prediction_ids, target_ids],
       [tf.float64, tf.float64, tf.float64, tf.float64])


### PR DESCRIPTION
Currently unit tests on master fail with [`AttributeError: module 'tensorflow' has no attribute 'py_function'`](https://travis-ci.org/tensorflow/tensor2tensor/jobs/477996581#L2440).

Unfortunately this is hard to spot since Python 2 builds are failing due to #1319 and Python 3 builds are cluttered with `inspect.getargspec()` deprecation warnings from tensorflow.