### PR TITLE
Add labels to ml-engine job

### DIFF
--- a/tensor2tensor/utils/cloud_mlengine.py
+++ b/tensor2tensor/utils/cloud_mlengine.py
@@ -202,8 +202,15 @@ def configure_job():
     )
 
   timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-  job_name = "%s_%s_t2t_%s" % (FLAGS.model, FLAGS.problem, timestamp)
-  job_spec = {"jobId": job_name, "trainingInput": training_input}
+  job_spec = {
+    "jobId": "%s_%s_t2t_%s" % (FLAGS.model, FLAGS.problem, timestamp),
+    "labels": {
+      "model": FLAGS.model,
+      "problem": FLAGS.problem,
+      "hparams": FLAGS.hparams_set
+    },
+    "trainingInput": training_input,
+  }
   return job_spec
 
 


### PR DESCRIPTION
Cloud ML Engine can use [labels](
https://cloud.google.com/ml-engine/docs/tensorflow/resource-labels) to organize and filter jobs.

This PR adds labels for `model`, `problem` and `hparams_set`.