### PR TITLE
Mixed Precision Support for Transformer

### DIFF
--- a/tensor2tensor/layers/common_hparams.py
+++ b/tensor2tensor/layers/common_hparams.py
@@ -70,6 +70,11 @@ def basic_params1():
       optimizer_adafactor_multiply_by_parameter_scale=True,
       # Number of accumulating steps for multi step optimizers.
       optimizer_multistep_accumulate_steps=None,
+      # Loss scaling used.
+      # Generally only necessary with mixed precision training.
+      # Mixed precision training only supports exponential scaling currently
+      # To disable the scaler, see to 0/False
+      mixed_precision_optimizer_loss_scaler='exponential',
       # Whether to zero gradients that were not computed, so that the
       # appropriate slots are created. Useful for sharing checkpoints between
       # models with different sets of heads.

--- a/tensor2tensor/layers/modalities.py
+++ b/tensor2tensor/layers/modalities.py
@@ -111,7 +111,7 @@ class SymbolModality(modality.Modality):
       ret = common_layers.gather(var, x)
       if self._model_hparams.multiply_embedding_mode == "sqrt_depth":
         ret *= self._body_input_depth**0.5
-      ret *= tf.expand_dims(tf.to_float(tf.not_equal(x, 0)), -1)
+      ret *= tf.expand_dims(common_layers.cast_like(tf.not_equal(x, 0), ret), -1)
       return ret
 
   def bottom(self, x):
@@ -148,7 +148,6 @@ class SymbolModality(modality.Modality):
     else:
       scope_name = "softmax"
       reuse = False
-
     with tf.variable_scope(scope_name, reuse=reuse):
       body_output_shape = common_layers.shape_list(body_output)
       var = self._get_weights(body_output_shape[-1])

--- a/tensor2tensor/layers/transformer_layers.py
+++ b/tensor2tensor/layers/transformer_layers.py
@@ -88,8 +88,7 @@ def transformer_prepare_encoder(inputs, target_space, hparams, features=None):
         32,
         ishape_static[-1],
         name="target_space_embedding",
-        dtype=tf.bfloat16
-        if hparams.activation_dtype == "bfloat16" else tf.float32)
+        dtype=hparams.activation_dtype)
     emb_target_space = tf.reshape(emb_target_space, [1, 1, -1])
     encoder_input += emb_target_space
   if hparams.pos == "timing":
@@ -102,11 +101,9 @@ def transformer_prepare_encoder(inputs, target_space, hparams, features=None):
     encoder_input = common_attention.add_positional_embedding(
         encoder_input, hparams.max_length, "inputs_positional_embedding",
         inputs_position)
-  if hparams.activation_dtype == "bfloat16":
-    encoder_self_attention_bias = tf.cast(encoder_self_attention_bias,
-                                          tf.bfloat16)
-    encoder_decoder_attention_bias = tf.cast(encoder_decoder_attention_bias,
-                                             tf.bfloat16)
+  
+  encoder_self_attention_bias = common_layers.cast_like(encoder_self_attention_bias, encoder_input)
+  encoder_decoder_attention_bias = common_layers.cast_like(encoder_decoder_attention_bias, encoder_input)
   return (encoder_input, encoder_self_attention_bias,
           encoder_decoder_attention_bias)
 
@@ -196,7 +193,9 @@ def transformer_encoder(encoder_input,
               make_image_summary=make_image_summary,
               dropout_broadcast_dims=attention_dropout_broadcast_dims,
               max_length=hparams.get("max_length"),
-              vars_3d=hparams.get("attention_variables_3d"))
+              vars_3d=hparams.get("attention_variables_3d"),
+              activation_dtype=hparams.activation_dtype,
+              weight_dtype=hparams.weight_dtype)
           x = common_layers.layer_postprocess(x, y, hparams)
         with tf.variable_scope("ffn"):
           y = transformer_ffn_layer(

--- a/tensor2tensor/models/__init__.py
+++ b/tensor2tensor/models/__init__.py
@@ -29,7 +29,7 @@ from tensor2tensor.models import lstm
 from tensor2tensor.models import mtf_image_transformer
 from tensor2tensor.models import mtf_resnet
 from tensor2tensor.models import mtf_transformer
-#from tensor2tensor.models import mtf_transformer2
+from tensor2tensor.models import mtf_transformer2
 from tensor2tensor.models import neural_gpu
 from tensor2tensor.models import resnet
 from tensor2tensor.models import revnet

--- a/tensor2tensor/models/__init__.py
+++ b/tensor2tensor/models/__init__.py
@@ -29,7 +29,7 @@ from tensor2tensor.models import lstm
 from tensor2tensor.models import mtf_image_transformer
 from tensor2tensor.models import mtf_resnet
 from tensor2tensor.models import mtf_transformer
-from tensor2tensor.models import mtf_transformer2
+#from tensor2tensor.models import mtf_transformer2
 from tensor2tensor.models import neural_gpu
 from tensor2tensor.models import resnet
 from tensor2tensor.models import revnet

--- a/tensor2tensor/models/transformer.py
+++ b/tensor2tensor/models/transformer.py
@@ -1293,7 +1293,9 @@ def transformer_decoder(decoder_input,
               dropout_broadcast_dims=attention_dropout_broadcast_dims,
               max_length=hparams.get("max_length"),
               decode_loop_step=decode_loop_step,
-              vars_3d=hparams.get("attention_variables_3d"))
+              vars_3d=hparams.get("attention_variables_3d"),
+              activation_dtype=hparams.activation_dtype,
+              weight_dtype=hparams.weight_dtype)
           x = common_layers.layer_postprocess(x, y, hparams)
         if encoder_output is not None:
           with tf.variable_scope("encdec_attention"):
@@ -1315,7 +1317,9 @@ def transformer_decoder(decoder_input,
                 make_image_summary=make_image_summary,
                 dropout_broadcast_dims=attention_dropout_broadcast_dims,
                 max_length=hparams.get("max_length"),
-                vars_3d=hparams.get("attention_variables_3d"))
+                vars_3d=hparams.get("attention_variables_3d"),
+                activation_dtype=hparams.activation_dtype,
+                weight_dtype=hparams.weight_dtype)
             x = common_layers.layer_postprocess(x, y, hparams)
         with tf.variable_scope("ffn"):
           y = transformer_ffn_layer(
@@ -2150,6 +2154,15 @@ def transformer_tpu_bf16_activation():
   hparams.activation_dtype = "bfloat16"
   return hparams
 
+@registry.register_hparams
+def transformer_fairseq_fp16_activation_big():
+  """
+  Hparams intended to mirror those used in https://arxiv.org/pdf/1806.00187.pdf
+  """
+  hparams = transformer_big()
+  hparams.activation_dtype = 'float16'
+  hparams.batch_size = 3584
+  return hparams
 
 @registry.register_hparams
 def transformer_packed_tpu():

--- a/tensor2tensor/utils/modality.py
+++ b/tensor2tensor/utils/modality.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 from tensor2tensor.layers import common_layers
 from tensor2tensor.utils import misc_utils
+from tensor2tensor.layers.common_attention import maybe_upcast
 
 import tensorflow as tf
 
@@ -181,6 +182,7 @@ class Modality(object):
     logits = top_out
     if weights_fn is None:
       weights_fn = self.targets_weights_fn
+    logits = maybe_upcast(logits,hparams=self._model_hparams)
     return common_layers.padded_cross_entropy(
         logits,
         targets,

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -27,7 +27,9 @@ from tensor2tensor.utils import yellowfin
 
 import tensorflow as tf
 
+from tensorflow.contrib.mixed_precision import LossScaleOptimizer
 from tensorflow.python.framework import dtypes
+from tensor2tensor.layers.common_attention import mixed_precision_is_enabled
 
 
 def optimize(loss, learning_rate, hparams, use_tpu=False, variables=None):
@@ -55,7 +57,6 @@ def optimize(loss, learning_rate, hparams, use_tpu=False, variables=None):
   opt = ConditionalOptimizer(hparams.optimizer, learning_rate, hparams, use_tpu)
   if use_tpu:
     opt = tf.contrib.tpu.CrossShardOptimizer(opt)
-
   opt_summaries = []
   if common_layers.should_generate_summaries():
     tf.summary.scalar("learning_rate", learning_rate)
@@ -152,11 +153,30 @@ class ConditionalOptimizer(tf.train.Optimizer):
       self._opt = adafactor.adafactor_optimizer_from_hparams(hparams, lr)
     else:
       self._opt = tf.contrib.layers.OPTIMIZER_CLS_NAMES[optimizer_name](lr)
+    if mixed_precision_is_enabled(hparams=hparams):
+      if not hparams.mixed_precision_optimizer_loss_scaler:
+        tf.logging.warning(("Using mixed precision without a loss scaler will ",
+                           "likely cause numerical errors."))
+      elif hparams.mixed_precision_optimizer_loss_scaler != 'exponential':
+        raise ValueError(("Mixed precision training only supports the ",
+                         "exponential loss scaler"))
+      else:
+        tf.logging.info("Using Exponential Update Loss Scaler")
+        loss_scale_manager = tf.contrib.mixed_precision.ExponentialUpdateLossScaleManager(
+            init_loss_scale=2**15,
+            incr_every_n_steps=2000,
+            decr_every_n_nan_or_inf=2,
+            incr_ratio=2,
+            decr_ratio=0.5)
+        self._opt = LossScaleOptimizer(self._opt, loss_scale_manager)
+
 
     self._zero_grads = hparams.optimizer_zero_grads
 
   def compute_gradients(self, loss, var_list=None, **kwargs):  # pylint: disable=arguments-differ
     gradients = self._opt.compute_gradients(loss, var_list, **kwargs)
+    # print("var list:", var_list)
+    # print("Gradients before cast", gradients)
     def cast_grad(g, v):
       if v is not None and g is not None:
         g = common_layers.cast_like(g, v)
@@ -164,6 +184,7 @@ class ConditionalOptimizer(tf.train.Optimizer):
         g = tf.zeros_like(v)
       return (g, v)
     gradients = [cast_grad(g, v) for g, v in gradients]
+    # print("Gradients after cast", gradients)
     return gradients
 
   def apply_gradients(self, grads_and_vars, global_step=None, name=None):

--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -31,6 +31,7 @@ from tensor2tensor.data_generators import multi_problem
 from tensor2tensor.data_generators import text_encoder
 from tensor2tensor.data_generators.problem import problem_hparams_to_features
 from tensor2tensor.layers import common_layers
+from tensor2tensor.layers.common_attention import mixed_precision_is_enabled
 from tensor2tensor.utils import beam_search
 from tensor2tensor.utils import decoding
 from tensor2tensor.utils import expert_utils as eu
@@ -273,6 +274,8 @@ class T2TModel(base.Layer):
           activation_dtype=activation_dtype)
     elif self.hparams.activation_dtype == "bfloat16":
       return quantization.bfloat16_activations_var_getter
+    elif mixed_precision_is_enabled(hparams=self.hparams):
+      return quantization.float16_activations_var_getter
     else:
       return None
 


### PR DESCRIPTION
Hi T2T team,

This is a first-pass attempt at providing mixed-precision support to Transformer on tensor2tensor.  Per discussion on gitter with @lukaszkaiser, this branch does *not* yet achieve all the speedups we expect, but he suggested we put up this branch and perhaps the t2t team will see something subtle (or obvious...) that we missed and we can all get performance where it should be, and merge strong mixed precision support into t2t.

## Our baseline:
* We have been gradually trying to replicate the results of fairseq’s “Scaling Neural Machine Translation”, https://arxiv.org/abs/1806.00187.  This paper demonstrates increased training speed (both wall clock and fundamental efficiency) on transformer translation through mixed precision and some other tricks.  Table 1 is the core result. (Trying to simply replicate their 8x V100 results pointed us to the need to enable https://github.com/tensorflow/tensor2tensor/blob/acde95f6cea575c1e5009d7a16d95545a23e0552/tensor2tensor/bin/t2t_trainer.py#L72 on 8x; with the flag, t2t is close to parity, without, it is ~½ speed of FB results.)
* In their paper, fairseq shows ~3x speedup (steps/s) from mixed precision (over full precision)
* We picked up Fairseq’s repo and did replicate their mixed precision 8x throughput results on a Docker image. 
* We have not been able to fully replicate on t2t (the branch with this PR).

## Our results:
* All below results are 1x V100, to simplify (although we did run some 8x to confirm things are not magically fixed in that scenario)
* We tried to match hparams between t2t & fairseq, including batch size, as closely as possible (see later notes on hparams)
* T2t, full precision -> mixed: ~2.2 steps/s -> ~3.3 steps/s (~1.5x speedup)
* Fairseq, full precision -> mixed: ~2.6 steps/s -> ~6.2 steps/s (~2.4x speedup)
* NOTE #1: this observed fairseq improvement grows to ~2.7, close to paper, on 8x
* NOTE #2: steps/s between t2t and fairseq were a little hard to compare apples:apples, based on fairseq reported/reports various numbers, but I believe the relative speedups are still meaningful

## Our approach: 
* We tried to follow the guidelines in https://docs.nvidia.com/deeplearning/sdk/mixed-precision-training/#tensorflow, which fairly well mirrors some of the logic t2t already has in place (https://github.com/tensorflow/tensor2tensor/blob/acde95f6cea575c1e5009d7a16d95545a23e0552/tensor2tensor/utils/t2t_model.py#L264).  It also seems to have been fairly successfully applied to the BERT repo (https://github.com/google-research/bert/pull/255, “--use-fp16 on its own gives nearly a 2.5x performance boost and it runs smoothly.”, although we did not directly review this claim).

## Diagnosing:
* We went fairly deep into t2t, and tried disabling (not included in this PR) various casts (such as in compute_grads) and other activities that could even vaguely conceivably be having a bad interaction effect.  No improvement (obviously, we may have missed something…).
* As a separate test (not included in this branch), we also tried using the alternate nvidia approach in https://nvidia.github.io/OpenSeq2Seq/html/mixed-precision.html#prerequisites, but didn’t meaningfully change throughput
* Printing out all of the variables in the custom getter shows all variables are returned as fp16.  For diagnosis purposes, this printing code is left in the custom_getter and compute_gradient functions; will be removed before merge.


## Test environment:
* Tested variously on CUDA 9.2 & 10 (since >CUDA 9.0 is needed for full mixed precision support; see https://nvidia.github.io/OpenSeq2Seq/html/mixed-precision.html#prerequisites; we also verified this the hard way…)
* TF1.12
* Ubuntu 16 (Python 3.5) & 18 (Python 3.6)
* Problem = translate_ende_wmt32k
* Hparams = transformer_fairseq_fp16_activation_big (note: this is included in branch; before merge, this could conceivably be removed)
* (note: only change here from the base hparam set is that we set mixed precision, and set the token count to match fairseq’s run, https://github.com/pytorch/fairseq/blob/b87c536651649ad71dd8766a409ef1c032b55afa/examples/translation/README.md#L164)
* Model = transformer
* Command to test with (assuming Cuda > 9.0, on Ubuntu 16 / 18 and TF1.12)
```
python3 tensor2tensor/bin/t2t-trainer --problem="translate_ende_wmt32k" --model="transformer" --hparams_set="transformer_fairseq_fp16_activation_big" --train_steps="5000" --eval_early_stopping_steps="10000" --eval_steps="3" --iterations_per_loop="2000" --keep_checkpoint_max="80" --local_eval_frequency="2000" --generate_data="False" --tmp_dir="t2t_tmp_dir" --data_dir="<data_dir>" --output_dir="output_dir”
```

## Known technical deficiencies/issues:
* No unit tests -- can add once design & functionality settle (didn’t put in place in case you have radical design changes to suggest)
* Only tested to successfully work with vanilla Transformer (and will almost certainly fail with many other models) -- happy to discuss either generalizing for it to work throughout the code base, or, for now, to add a gate s.t. if mixed precision is on for any model/hparams other than vanilla Transformer, it refuses to run (and then this can be relaxed in a separate PR/over time).
* Passing around weight types in certain places definitely feels hacky (something like being able to universally call self.activation_dtype, etc. would feel much better, like in https://github.com/tensorflow/tensor2tensor/blob/44f669058390bec03024baa04c1a33e91cc0909d/tensor2tensor/models/mtf_transformer.py#L119).  Given how the codebase is right now, not obvious to me how to do so, but open to suggestions.
* When the mixed precision getter is invoked, it *always* forces all variables to be cast down to fp16.  This simplifies the code base, but is a different behavior than the other getters in the t2t code base; it works in this specific use case, but possibly doesn’t generalize.  Open to discussion here.
* We’ve placed some our functionality at the top of common_attention.py. We’d like your feedback on a more appropriate location in the code base.
* For convenience, there are a few debug statements that are simply commented out within branch.  We will remove those before merge.
