### PR TITLE
Exclude .git directory when submitting to Cloud ML Engine

### DIFF
--- a/tensor2tensor/utils/cloud_mlengine.py
+++ b/tensor2tensor/utils/cloud_mlengine.py
@@ -232,7 +232,7 @@ def _tar_and_copy(src_dir, target_dir):
   tmp_dir = tempfile.gettempdir().rstrip("/")
   src_base = os.path.basename(src_dir)
   shell_run(
-      "tar -zcf {tmp_dir}/{src_base}.tar.gz -C {src_dir} .",
+      "tar --exclude=.git -zcf {tmp_dir}/{src_base}.tar.gz -C {src_dir} .",
       src_dir=src_dir,
       src_base=src_base,
       tmp_dir=tmp_dir)


### PR DESCRIPTION
The `.git` directory isn't used on Cloud ML Engine, therefor we should ignore it in the uploaded archive.

This reduces the size of the `.tar.gz` archive from a fresh clone of `tensor2tensor` from 15 MB to only 3.6 MB.