### PR TITLE
Pretty print Cloud ML Engine job spec

### DIFF
--- a/tensor2tensor/utils/cloud_mlengine.py
+++ b/tensor2tensor/utils/cloud_mlengine.py
@@ -17,6 +17,7 @@
 
 import datetime
 import os
+import pprint
 import shutil
 import subprocess as sp
 import sys
@@ -378,7 +379,7 @@ def launch():
   job_spec = configure_job()
   job_name = job_spec["jobId"]
   tf.logging.info("Launching job %s with ML Engine spec:\n%s", job_name,
-                  job_spec)
+                  pprint.pformat(job_spec))
   assert confirm()
   train_dir = FLAGS.output_dir
   t2t_tar = tar_and_copy_t2t(train_dir)


### PR DESCRIPTION
Currently the ML Engine jobs spec is hard to read. This PR formats the job spec for better readability.

### Example output using this PR:
```
INFO:tensorflow:Launching job shake_shake_image_mnist_t2t_20190113_170945 with ML Engine spec:
{'jobId': 'shake_shake_image_mnist_t2t_20190113_170945',
 'labels': {'hparams': 'shake_shake_quick',
            'model': 'shake_shake',
            'problem': 'image_mnist'},
 'trainingInput': {'args': ['--disable_ffmpeg=False',
                            '--timit_paths=',
                            '--wiki_revision_num_train_shards=50',
                            '--wiki_revision_num_dev_shards=1',
                            '--wiki_revision_data_prefix=',
                            '--wiki_revision_vocab_file=',
                            '--wiki_revision_max_examples_per_shard=0',
                            '--wiki_revision_max_page_size_exp=26',
                            '--wiki_revision_max_equal_to_diff_ratio=0.0',
                            '--wiki_revision_revision_skip_factor=1.5',
                            '--wiki_revision_percent_identical_examples=0.04',
                            '--wiki_revision_introduce_errors=True',
                            '--parsing_path=',
                            '--registry_help=False',
                            '--tfdbg=False',
                            '--export_saved_model=False',
                            '--dbgprofile=False',
                            '--model=shake_shake',
                            '--hparams_set=shake_shake_quick',
                            '--hparams=',
                            '--problem=image_mnist',
                            '--data_dir=gs://lgeiger-test-bucket/data',
                            '--train_steps=5000',
                            '--eval_early_stopping_metric=loss',
                            '--eval_early_stopping_metric_delta=0.1',
                            '--eval_early_stopping_metric_minimize=True',
                            '--eval_timeout_mins=240',
                            '--eval_run_autoregressive=False',
                            '--eval_use_test_set=False',
                            '--keep_checkpoint_max=20',
                            '--enable_graph_rewriter=False',
                            '--keep_checkpoint_every_n_hours=10000',
                            '--save_checkpoints_secs=0',
                            '--log_device_placement=False',
                            '--local_eval_frequency=1000',
                            '--eval_throttle_seconds=600',
                            '--sync=False',
                            '--worker_job=/job:localhost',
                            '--worker_gpu=1',
                            '--worker_replicas=1',
                            '--worker_id=0',
                            '--worker_gpu_memory_fraction=0.95',
                            '--ps_gpu=0',
                            '--gpu_order=',
                            '--ps_job=/job:ps',
                            '--ps_replicas=0',
                            '--decode_hparams=',
                            '--tpu_num_shards=8',
                            '--iterations_per_loop=100',
                            '--use_tpu=False',
                            '--use_tpu_estimator=False',
                            '--xla_compile=False',
                            '--xla_jit_level=-1',
                            '--generate_data=False',
                            '--tmp_dir=/tmp/t2t_datagen',
                            '--profile=False',
                            '--inter_op_parallelism_threads=0',
                            '--intra_op_parallelism_threads=0',
                            '--optionally_use_dist_strat=False',
                            '--master=',
                            '--output_dir=gs://lgeiger-test-bucket/train3',
                            '--schedule=continuous_train_and_eval',
                            '--eval_steps=100',
                            '--std_server_protocol=grpc',
                            '--cloud_tpu_name=lukasgeiger-tpu',
                            '--log_step_count_steps=100'],
                   'jobDir': 'gs://lgeiger-test-bucket/train3',
                   'masterType': 'standard_p100',
                   'pythonModule': 'tensor2tensor.bin.t2t_trainer',
                   'pythonVersion': '3.5',
                   'region': 'europe-west1',
                   'runtimeVersion': '1.12',
                   'scaleTier': 'CUSTOM'}}
Confirm (Y/n)? >
```

### Example output on master:

```
INFO:tensorflow:Launching job shake_shake_image_mnist_t2t_20190113_170622 with ML Engine spec:
{'jobId': 'shake_shake_image_mnist_t2t_20190113_170622', 'labels': {'model': 'shake_shake', 'problem': 'image_mnist', 'hparams': 'shake_shake_quick'}, 'trainingInput': {'pythonModule': 'tensor2tensor.bin.t2t_trainer', 'args': ['--disable_ffmpeg=False', '--timit_paths=', '--wiki_revision_num_train_shards=50', '--wiki_revision_num_dev_shards=1', '--wiki_revision_data_prefix=', '--wiki_revision_vocab_file=', '--wiki_revision_max_examples_per_shard=0', '--wiki_revision_max_page_size_exp=26', '--wiki_revision_max_equal_to_diff_ratio=0.0', '--wiki_revision_revision_skip_factor=1.5', '--wiki_revision_percent_identical_examples=0.04', '--wiki_revision_introduce_errors=True', '--parsing_path=', '--registry_help=False', '--tfdbg=False', '--export_saved_model=False', '--dbgprofile=False', '--model=shake_shake', '--hparams_set=shake_shake_quick', '--hparams=', '--problem=image_mnist', '--data_dir=gs://lgeiger-test-bucket/data', '--train_steps=5000', '--eval_early_stopping_metric=loss', '--eval_early_stopping_metric_delta=0.1', '--eval_early_stopping_metric_minimize=True', '--eval_timeout_mins=240', '--eval_run_autoregressive=False', '--eval_use_test_set=False', '--keep_checkpoint_max=20', '--enable_graph_rewriter=False', '--keep_checkpoint_every_n_hours=10000', '--save_checkpoints_secs=0', '--log_device_placement=False', '--local_eval_frequency=1000', '--eval_throttle_seconds=600', '--sync=False', '--worker_job=/job:localhost', '--worker_gpu=1', '--worker_replicas=1', '--worker_id=0', '--worker_gpu_memory_fraction=0.95', '--ps_gpu=0', '--gpu_order=', '--ps_job=/job:ps', '--ps_replicas=0', '--decode_hparams=', '--tpu_num_shards=8', '--iterations_per_loop=100', '--use_tpu=False', '--use_tpu_estimator=False', '--xla_compile=False', '--xla_jit_level=-1', '--generate_data=False', '--tmp_dir=/tmp/t2t_datagen', '--profile=False', '--inter_op_parallelism_threads=0', '--intra_op_parallelism_threads=0', '--optionally_use_dist_strat=False', '--master=', '--output_dir=gs://lgeiger-test-bucket/train3', '--schedule=continuous_train_and_eval', '--eval_steps=100', '--std_server_protocol=grpc', '--cloud_tpu_name=lukasgeiger-tpu', '--log_step_count_steps=100'], 'region': 'europe-west1', 'runtimeVersion': '1.12', 'pythonVersion': '3.5', 'jobDir': 'gs://lgeiger-test-bucket/train3', 'scaleTier': 'CUSTOM', 'masterType': 'standard_p100'}}
Confirm (Y/n)? >
```
