### PR TITLE
Combine AUT variants into a single function and define mix_with_transformer

### DIFF
--- a/tensor2tensor/models/research/universal_transformer.py
+++ b/tensor2tensor/models/research/universal_transformer.py
@@ -362,9 +362,9 @@ def update_hparams_for_universal_transformer(hparams):
   """
   hparams.daisy_chain_variables = False  # Breaks multi-gpu in while loops.
 
-  # If not None, mixes vanilla transformer with Universal Transformer.
-  # Options: None, "before_ut", and "after_ut".
-  hparams.add_hparam("mix_with_transformer", None)
+  # If not "", mixes vanilla transformer with Universal Transformer.
+  # Options: "", "before_ut", and "after_ut".
+  hparams.add_hparam("mix_with_transformer", "")
 
   # Number of vanilla transformer layers used to be mixed with u-transofmer.
   hparams.add_hparam("num_mixedin_layers", 2)

--- a/tensor2tensor/models/research/universal_transformer.py
+++ b/tensor2tensor/models/research/universal_transformer.py
@@ -362,9 +362,9 @@ def update_hparams_for_universal_transformer(hparams):
   """
   hparams.daisy_chain_variables = False  # Breaks multi-gpu in while loops.
 
-  # If not "", mixes vanilla transformer with Universal Transformer.
-  # Options: "", "before_ut", and "after_ut".
-  hparams.add_hparam("mix_with_transformer", "")
+  # If not None, mixes vanilla transformer with Universal Transformer.
+  # Options: None, "before_ut", and "after_ut".
+  hparams.add_hparam("mix_with_transformer", None)
 
   # Number of vanilla transformer layers used to be mixed with u-transofmer.
   hparams.add_hparam("num_mixedin_layers", 2)

--- a/tensor2tensor/models/research/universal_transformer_util.py
+++ b/tensor2tensor/models/research/universal_transformer_util.py
@@ -234,7 +234,6 @@ def universal_transformer_layer(x,
     return x
 
   with tf.variable_scope("universal_transformer_%s" % hparams.recurrence_type):
-
     if "before_ut" in hparams.mix_with_transformer:
       x = add_vanilla_transformer_layer(x, hparams.num_mixedin_layers,
                                         "before_ut_")
@@ -1038,6 +1037,11 @@ def universal_transformer_act(x, hparams, ffn_unit, attention_unit):
 
   Implementations of all act models are based on craffel@'s cl/160711592.
 
+    basic - Basic AUT based on remainder-distribution ACT (position-wise).
+    global - AUT with global halting probability (not position-wise).
+    random - AUT with random halting probability (not position-wise).
+    accumulated - AUT with final state as accumulation of all states. Similar to the main ACT paper: --> check the issue of differentiability
+    
   Args:
     x: input
     hparams: model hyper-parameters
@@ -1052,65 +1056,30 @@ def universal_transformer_act(x, hparams, ffn_unit, attention_unit):
 
   """
   # TODO(dehghani): Enable pad_remover for the act computations.
-  if hparams.act_type == "basic":
-    return universal_transformer_act_basic(
-        x, hparams, ffn_unit, attention_unit)
 
-  elif hparams.act_type == "accumulated":
-    return universal_transformer_act_accumulated(
-        x, hparams, ffn_unit, attention_unit)
-
-  elif hparams.act_type == "global":
-    return universal_transformer_act_global(
-        x, hparams, ffn_unit, attention_unit)
-
-  elif hparams.act_type == "random":
-    return universal_transformer_act_random(
-        x, hparams, ffn_unit, attention_unit)
-
-  else:
+  if hparams.act_type not in ["basic","global","random","accumulated"]:
     raise ValueError("Unknown act type: %s" % hparams.act_type)
-
-
-def universal_transformer_act_basic(x, hparams, ffn_unit, attention_unit):
-  """Basic universal_transformer with ACT based on remainder-distribution ACT.
-
-  Args:
-    x: input
-    hparams: model hyper-parameters
-    ffn_unit: feed-forward unit
-    attention_unit: multi-head attention unit
-
-  Returns:
-    the output tensor,  (ponder_times, remainders)
-
-  """
-
+    
   state = x
   act_max_steps = hparams.act_max_steps
   threshold = 1.0 - hparams.act_epsilon
+  state_shape_static = state.get_shape()
 
-  batch_size = tf.shape(state)[0]
-  length = tf.shape(state)[1]
-
+  state_slice = slice(0,2)
+  if hparams.act_type == "global":
+    state_slice = slice(0,1)
+    
+  # Dynamic shape for update tensors below
+  update_shape = tf.shape(state)[state_slice]
+    
   # Halting probabilities (p_t^n in the paper)
-  halting_probability = tf.zeros(
-      (
-          batch_size,
-          length,
-      ), name="halting_probability")
+  halting_probability = tf.zeros(update_shape, name="halting_probability")
+  
   # Remainders (R(t) in the paper)
-  remainders = tf.zeros(
-      (
-          batch_size,
-          length,
-      ), name="remainder")
+  remainders = tf.zeros(update_shape, name="remainder")
+  
   # Number of updates performed (N(t) in the paper)
-  n_updates = tf.zeros(
-      (
-          batch_size,
-          length,
-      ), name="n_updates")
+  n_updates = tf.zeros(update_shape, name="n_updates")
 
   # Previous cell states (s_t in the paper)
   previous_state = tf.zeros_like(state, name="previous_state")
@@ -1136,19 +1105,30 @@ def universal_transformer_act_basic(x, hparams, ffn_unit, attention_unit):
       n_updates: act n_updates
       new_state: new state
     """
-    state_shape = state.get_shape()
+
     state = step_preprocess(state, step, hparams)
 
-    with tf.variable_scope("sigmoid_activation_for_pondering"):
-      p = common_layers.dense(
-          state,
-          1,
-          activation=tf.nn.sigmoid,
-          use_bias=True,
-          bias_initializer=tf.constant_initializer(
-              hparams.act_halting_bias_init))
-      p = tf.squeeze(p, axis=-1)
+    if hparams.act_type == "random":
+        # random as halting probability
+        p = tf.random_uniform(shape=common_layers.shape_list(halting_probability))
+    else:
+        with tf.variable_scope("sigmoid_activation_for_pondering"):
+          p = common_layers.dense(
+              state,
+              1,
+              activation=tf.nn.sigmoid,
+              use_bias=True,
+              bias_initializer=tf.constant_initializer(
+                  hparams.act_halting_bias_init))
 
+          if hparams.act_type == "global":
+            # average over all positions (as a global halting prob)
+            p = tf.reduce_mean(p, axis=1)
+            p = tf.squeeze(p)
+          else:
+            #maintain position-wise probabilities
+            p = tf.squeeze(p, axis=-1)
+            
     # Mask for inputs which have not halted yet
     still_running = tf.cast(tf.less(halting_probability, 1.0), tf.float32)
 
@@ -1181,7 +1161,9 @@ def universal_transformer_act_basic(x, hparams, ffn_unit, attention_unit):
     # the remainders when it halted this step
     update_weights = tf.expand_dims(p * still_running + new_halted * remainders,
                                     -1)
-
+    if hparams.act_type == "global":
+        update_weights = tf.expand_dims(update_weights, -1)
+        
     # apply transformation on the state
     transformed_state = state
     for i in range(hparams.num_inrecurrence_layers):
@@ -1190,16 +1172,17 @@ def universal_transformer_act_basic(x, hparams, ffn_unit, attention_unit):
 
     # update running part in the weighted state and keep the rest
     new_state = ((transformed_state * update_weights) +
-                 (previous_state * (1 - update_weights)))
+             (previous_state * (1 - update_weights)))
+        
+    if hparams.act_type == "accumulated":
+        # Add in the weighted state
+        new_state = (transformed_state * update_weights) + previous_state
 
     # remind TensorFlow of everything's shape
-    transformed_state.set_shape(state_shape)
+    transformed_state.set_shape(state_shape_static)
     for x in [halting_probability, remainders, n_updates]:
-      x.set_shape([
-          state_shape[0],
-          state_shape[1],
-      ])
-    new_state.set_shape(state_shape)
+      x.set_shape(state_shape_static[state_slice])
+    new_state.set_shape(state_shape_static)
     step += 1
     return (transformed_state, step, halting_probability, remainders, n_updates,
             new_state)
@@ -1225,460 +1208,6 @@ def universal_transformer_act_basic(x, hparams, ffn_unit, attention_unit):
   tf.contrib.summary.scalar("ponder_times", tf.reduce_mean(ponder_times))
 
   return new_state, (ponder_times, remainders)
-
-
-def universal_transformer_act_accumulated(x, hparams, ffn_unit, attention_unit):
-  """The UTAct layer where the final state is the accumulation of all states.
-
-    (similar to the main ACT paper: --> check the issue of differentiability)
-
-  Args:
-    x: input
-    hparams: model hyper-parameters
-    ffn_unit: feed-forward unit
-    attention_unit: multi-head attention unit
-
-  Returns:
-    the output tensor,  (ponder_times, remainders)
-
-  """
-  state = x
-  act_max_steps = hparams.act_max_steps
-  threshold = 1.0 - hparams.act_epsilon
-
-  batch_size = tf.shape(state)[0]
-  length = tf.shape(state)[1]
-
-  # Halting probabilities (p_t^n in the paper)
-  halting_probability = tf.zeros(
-      (
-          batch_size,
-          length,
-      ), name="halting_probability")
-  # Remainders (R(t) in the paper)
-  remainders = tf.zeros(
-      (
-          batch_size,
-          length,
-      ), name="remainder")
-  # Number of updates performed (N(t) in the paper)
-  n_updates = tf.zeros(
-      (
-          batch_size,
-          length,
-      ), name="n_updates")
-
-  # Accumulated cell states (s_t in the paper)
-  accumulated_state = tf.zeros_like(state, name="previous_state")
-  step = tf.constant(0, dtype=tf.int32)
-
-  def ut_function(state, step, halting_probability, remainders, n_updates,
-                  accumulated_state):
-    """Position-wise act.
-
-    Args:
-      state: 3-D Tensor: [batch_size, length, channel]
-      step: indicates number of steps taken so far
-      halting_probability: halting probability
-      remainders: act remainders
-      n_updates: act n_updates
-      accumulated_state: accumulated state
-
-    Returns:
-      transformed_state: transformed state
-      step: step+1
-      halting_probability: halting probability
-      remainders: act remainders
-      n_updates: act n_updates
-      accumulated_state: accumulated state
-    """
-    state_shape = state.get_shape()
-    state = step_preprocess(state, step, hparams)
-
-    with tf.variable_scope("sigmoid_activation_for_pondering"):
-      p = common_layers.dense(
-          state,
-          1,
-          activation=tf.nn.sigmoid,
-          use_bias=True,
-          bias_initializer=tf.constant_initializer(
-              hparams.act_halting_bias_init))
-      p = tf.squeeze(p, axis=-1)
-
-    # Mask for inputs which have not halted yet
-    still_running = tf.cast(tf.less(halting_probability, 1.0), tf.float32)
-
-    # Mask of inputs which halted at this step
-    new_halted = tf.cast(
-        tf.greater(halting_probability + p * still_running, threshold),
-        tf.float32) * still_running
-
-    # Mask of inputs which haven't halted, and didn't halt this step
-    still_running = tf.cast(
-        tf.less_equal(halting_probability + p * still_running, threshold),
-        tf.float32) * still_running
-
-    # Add the halting probability for this step to the halting
-    # probabilities for those input which haven't halted yet
-    halting_probability += p * still_running
-
-    # Compute remainders for the inputs which halted at this step
-    remainders += new_halted * (1 - halting_probability)
-
-    # Add the remainders to those inputs which halted at this step
-    halting_probability += new_halted * remainders
-
-    # Increment n_updates for all inputs which are still running
-    n_updates += still_running + new_halted
-
-    # Compute the weight to be applied to the new state and output
-    # 0 when the input has already halted
-    # p when the input hasn't halted yet
-    # the remainders when it halted this step
-    update_weights = tf.expand_dims(p * still_running + new_halted * remainders,
-                                    -1)
-
-    # apply transformation on the state
-    new_state = state
-    for i in range(hparams.num_inrecurrence_layers):
-      with tf.variable_scope("rec_layer_%d" % i):
-        new_state = ffn_unit(attention_unit(new_state))
-
-    transformed_state = new_state
-
-    # Add in the weighted state
-    accumulated_state = (transformed_state * update_weights) + accumulated_state
-
-    # Remind TensorFlow of everything's shape
-    state.set_shape(state_shape)
-    for x in [halting_probability, remainders, n_updates]:
-      x.set_shape([
-          state_shape[0],
-          state_shape[1],
-      ])
-    accumulated_state.set_shape(state_shape)
-    step += 1
-    return (transformed_state, step, halting_probability, remainders, n_updates,
-            accumulated_state)
-
-  # While loop stops when this predicate is FALSE.
-  # Ie all (probability < 1-eps AND counter < N) are false.
-  def should_continue(u0, u1, halting_probability, u2, n_updates, u3):
-    del u0, u1, u2, u3
-    return tf.reduce_any(
-        tf.logical_and(
-            tf.less(halting_probability, threshold),
-            tf.less(n_updates, act_max_steps)))
-
-  # Do while loop iterations until predicate above is false.
-  (_, _, _, remainder, n_updates, accumulated_state) = tf.while_loop(
-      should_continue, ut_function, (state, step, halting_probability,
-                                     remainders, n_updates, accumulated_state),
-      maximum_iterations=act_max_steps + 1)
-
-  ponder_times = n_updates
-  remainders = remainder
-
-  tf.contrib.summary.scalar("ponder_times", tf.reduce_mean(ponder_times))
-
-  return accumulated_state, (ponder_times, remainders)
-
-
-def universal_transformer_act_global(x, hparams, ffn_unit, attention_unit):
-  """The UTAct  with global halting probability (not position-wise).
-
-  Args:
-    x: input
-    hparams: model hyper-parameters
-    ffn_unit: feed-forward unit
-    attention_unit: multi-head attention unit
-
-  Returns:
-    the output tensor,  (ponder_times, remainders)
-
-  """
-  state = x
-  act_max_steps = hparams.act_max_steps
-  threshold = 1.0 - hparams.act_epsilon
-  act_max_steps = hparams.act_max_steps
-  batch_size = tf.shape(state)[0]
-  state_shape = state.get_shape()
-
-  # Halting probabilities (p_t^n in the paper)
-  halting_probability = tf.zeros((batch_size,), name="halting_probability")
-  # Remainders (R(t) in the paper)
-  remainders = tf.zeros((batch_size,), name="remainder")
-  # Number of updates performed (N(t) in the paper)
-  n_updates = tf.zeros((batch_size,), name="n_updates")
-  # Previous cell states (s_t in the paper)
-  previous_state = tf.zeros_like(state, name="previous_state")
-  step = tf.constant(0, dtype=tf.int32)
-
-  def ut_function(state, step, halting_probability, remainders, n_updates,
-                  previous_state):
-    """implements act (global halting).
-
-    Args:
-      state: 3-D Tensor: [batch_size, length, channel]
-      step: indicates number of steps taken so far
-      halting_probability: halting probability
-      remainders: act remainders
-      n_updates: act n_updates
-      previous_state: previous state
-
-    Returns:
-      transformed_state: transformed state
-      step: step+1
-      halting_probability: halting probability
-      remainders: act remainders
-      n_updates: act n_updates
-      new_state: new state
-
-    """
-
-    state = step_preprocess(state, step, hparams)
-
-    with tf.variable_scope("sigmoid_activation_for_pondering"):
-      p = common_layers.dense(
-          state,
-          1,
-          activation=tf.nn.sigmoid,
-          use_bias=True,
-          bias_initializer=tf.constant_initializer(
-              hparams.act_halting_bias_init))
-      # average over all positions (as a global halting prob)
-      p = tf.reduce_mean(p, axis=1)
-      p = tf.squeeze(p)
-
-    # Mask for inputs which have not halted yet
-    still_running = tf.cast(tf.less(halting_probability, 1.0), tf.float32)
-
-    # Mask of inputs which halted at this step
-    new_halted = tf.cast(
-        tf.greater(halting_probability + p * still_running, threshold),
-        tf.float32) * still_running
-
-    # Mask of inputs which haven't halted, and didn't halt this step
-    still_running = tf.cast(
-        tf.less_equal(halting_probability + p * still_running, threshold),
-        tf.float32) * still_running
-
-    # Add the halting probability for this step to the halting
-    # probabilities for those input which haven't halted yet
-    halting_probability += p * still_running
-
-    # Compute remainders for the inputs which halted at this step
-    remainders += new_halted * (1 - halting_probability)
-
-    # Add the remainders to those inputs which halted at this step
-    halting_probability += new_halted * remainders
-
-    # Increment n_updates for all inputs which are still running
-    n_updates += still_running + new_halted
-
-    # Compute the weight to be applied to the new state and output
-    # 0 when the input has already halted
-    # p when the input hasn't halted yet
-    # the remainders when it halted this step
-    update_weights = tf.expand_dims(
-        tf.expand_dims(p * still_running + new_halted * remainders, -1), -1)
-
-    # apply transformation on the state
-    new_state = state
-    for i in range(hparams.num_inrecurrence_layers):
-      with tf.variable_scope("rec_layer_%d" % i):
-        new_state = ffn_unit(attention_unit(new_state))
-
-    transformed_state = new_state
-
-    # Add in the weighted state
-    new_state = ((transformed_state * update_weights) +
-                 (previous_state * (1 - update_weights)))
-
-    # Remind TensorFlow of everything's shape
-    state.set_shape(state_shape)
-    for x in [halting_probability, remainders, n_updates]:
-      x.set_shape([
-          state_shape[0],
-      ])
-    new_state.set_shape(state_shape)
-
-    step += 1
-    return (transformed_state, step, halting_probability,
-            remainders, n_updates, new_state)
-
-  # While loop stops when this predicate is FALSE.
-  # Ie all (probability < 1-eps AND counter < N) are false.
-  def should_continue(u0, u1, halting_probability, u2, n_updates, u3):
-    del u0, u1, u2, u3
-    return tf.reduce_any(
-        tf.logical_and(
-            tf.less(halting_probability, threshold),
-            tf.less(n_updates, act_max_steps)))
-
-  # Do while loop iterations until predicate above is false.
-  (_, _, _, remainder, n_updates, new_state) = tf.while_loop(
-      should_continue, ut_function,
-      (state, step, halting_probability, remainders, n_updates, previous_state),
-      maximum_iterations=act_max_steps + 1)
-
-  ponder_times = n_updates
-  remainders = remainder
-
-  tf.contrib.summary.scalar("ponder_times", tf.reduce_mean(ponder_times))
-
-  return new_state, (ponder_times, remainders)
-
-
-def universal_transformer_act_random(x, hparams, ffn_unit, attention_unit):
-  """universal_transformer with ACT with random halting probability.
-
-  Args:
-    x: input
-    hparams: model hyper-parameters
-    ffn_unit: feed-forward unit
-    attention_unit: multi-head attention unit
-
-  Returns:
-    the output tensor,  (ponder_times, remainders)
-
-  """
-  state = x
-  act_max_steps = hparams.act_max_steps
-  threshold = 1.0 - hparams.act_epsilon
-
-  batch_size = tf.shape(state)[0]
-  length = tf.shape(state)[1]
-
-  # Halting probabilities (p_t^n in the paper)
-  halting_probability = tf.zeros(
-      (
-          batch_size,
-          length,
-      ), name="halting_probability")
-  # Remainders (R(t) in the paper)
-  remainders = tf.zeros(
-      (
-          batch_size,
-          length,
-      ), name="remainder")
-  # Number of updates performed (N(t) in the paper)
-  n_updates = tf.zeros(
-      (
-          batch_size,
-          length,
-      ), name="n_updates")
-
-  # Previous cell states (s_t in the paper)
-  previous_state = tf.zeros_like(state, name="previous_state")
-  step = tf.constant(0, dtype=tf.int32)
-
-  def ut_function(state, step, halting_probability, remainders, n_updates,
-                  previous_state):
-    """Implements act (position-wise halting).
-
-    Args:
-      state: 3-D Tensor: [batch_size, length, channel]
-      step: indicates number of steps taken so far
-      halting_probability: halting probability
-      remainders: act remainders
-      n_updates: act n_updates
-      previous_state: previous state
-
-    Returns:
-      transformed_state: transformed state
-      step: step+1
-      halting_probability: halting probability
-      remainders: act remainders
-      n_updates: act n_updates
-      new_state: new state
-
-    """
-    state_shape = state.get_shape()
-    state = step_preprocess(state, step, hparams)
-
-    # random as halting probability
-    p = tf.random_uniform(shape=common_layers.shape_list(halting_probability))
-
-    # Mask for inputs which have not halted yet
-    still_running = tf.cast(tf.less(halting_probability, 1.0), tf.float32)
-
-    # Mask of inputs which halted at this step
-    new_halted = tf.cast(
-        tf.greater(halting_probability + p * still_running, threshold),
-        tf.float32) * still_running
-
-    # Mask of inputs which haven't halted, and didn't halt this step
-    still_running = tf.cast(
-        tf.less_equal(halting_probability + p * still_running, threshold),
-        tf.float32) * still_running
-
-    # Add the halting probability for this step to the halting
-    # probabilities for those input which haven't halted yet
-    halting_probability += p * still_running
-
-    # Compute remainders for the inputs which halted at this step
-    remainders += new_halted * (1 - halting_probability)
-
-    # Add the remainders to those inputs which halted at this step
-    halting_probability += new_halted * remainders
-
-    # Increment n_updates for all inputs which are still running
-    n_updates += still_running + new_halted
-
-    # Compute the weight to be applied to the new state and output
-    # 0 when the input has already halted
-    # p when the input hasn't halted yet
-    # the remainders when it halted this step
-    update_weights = tf.expand_dims(p * still_running + new_halted * remainders,
-                                    -1)
-
-    # apply transformation on the state
-    new_state = state
-    for i in range(hparams.num_inrecurrence_layers):
-      with tf.variable_scope("rec_layer_%d" % i):
-        new_state = ffn_unit(attention_unit(new_state))
-
-    transformed_state = new_state
-
-    # update running part in the weighted state and keep the rest
-    new_state = ((transformed_state * update_weights) +
-                 (previous_state * (1 - update_weights)))
-
-    # remind TensorFlow of everything's shape
-    transformed_state.set_shape(state_shape)
-    for x in [halting_probability, remainders, n_updates]:
-      x.set_shape([
-          state_shape[0],
-          state_shape[1],
-      ])
-    new_state.set_shape(state_shape)
-    step += 1
-    return (transformed_state, step,
-            halting_probability, remainders, n_updates, new_state)
-
-  # While loop stops when this predicate is FALSE.
-  # Ie all (probability < 1-eps AND counter < N) are false.
-  def should_continue(u0, u1, halting_probability, u2, n_updates, u3):
-    del u0, u1, u2, u3
-    return tf.reduce_any(
-        tf.logical_and(
-            tf.less(halting_probability, threshold),
-            tf.less(n_updates, act_max_steps)))
-
-  # Do while loop iterations until predicate above is false.
-  (_, _, _, remainder, n_updates, new_state) = tf.while_loop(
-      should_continue, ut_function,
-      (state, step, halting_probability, remainders, n_updates, previous_state),
-      maximum_iterations=act_max_steps + 1)
-
-  ponder_times = n_updates
-  remainders = remainder
-
-  tf.contrib.summary.scalar("ponder_times", tf.reduce_mean(ponder_times))
-
-  return new_state, (ponder_times, remainders)
-
 
 def _ffn_layer_multi_inputs(inputs_list,
                             hparams,

--- a/tensor2tensor/models/research/universal_transformer_util.py
+++ b/tensor2tensor/models/research/universal_transformer_util.py
@@ -234,7 +234,7 @@ def universal_transformer_layer(x,
     return x
 
   with tf.variable_scope("universal_transformer_%s" % hparams.recurrence_type):
-    if "before_ut" in hparams.mix_with_transformer:
+    if hparams.mix_with_transformer and "before_ut" in hparams.mix_with_transformer:
       x = add_vanilla_transformer_layer(x, hparams.num_mixedin_layers,
                                         "before_ut_")
 
@@ -256,7 +256,7 @@ def universal_transformer_layer(x,
           hparams.get("use_memory_as_final_state", False)):
         output = extra_output
 
-    if "after_ut" in hparams.mix_with_transformer:
+    if hparams.mix_with_transformer and "after_ut" in hparams.mix_with_transformer:
       output = add_vanilla_transformer_layer(output, hparams.num_mixedin_layers,
                                              "after_ut_")
 
@@ -1037,10 +1037,10 @@ def universal_transformer_act(x, hparams, ffn_unit, attention_unit):
 
   Implementations of all act models are based on craffel@'s cl/160711592.
 
-    basic - Basic AUT based on remainder-distribution ACT (position-wise).
-    global - AUT with global halting probability (not position-wise).
-    random - AUT with random halting probability (not position-wise).
-    accumulated - AUT with final state as accumulation of all states. Similar to the main ACT paper: --> check the issue of differentiability
+    (1) Basic AUT based on remainder-distribution ACT (position-wise).
+    (2) AUT with global halting probability (not position-wise).
+    (3) AUT with random halting probability (not position-wise).
+    (4) AUT with final state as accumulation of all states. Similar to the main ACT paper: --> check the issue of differentiability
     
   Args:
     x: input


### PR DESCRIPTION
Here I propose for the Universal Transformer with ACT with different `act_type`s to be combined into a single function to be more understandable. I believe that the proposed backwards-compatible change would benefit future variants. 