### PR TITLE
changed _normalize_body_output to sum the mean of each loss when loss…

### DIFF
--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -1691,15 +1691,12 @@ class T2TModel(base.Layer):
   def _normalize_body_output(self, body_out):
     if isinstance(body_out, tuple):
       output, losses = body_out
-      if isinstance(losses, list):
+      if isinstance(losses, (list, tuple)):
         losses = {"extra": tf.add_n([tf.reduce_mean(l) for l in losses])}
-      elif isinstance(losses, tf.Tensor):
-        losses = {"extra": tf.reduce_mean(losses)}
       elif isinstance(losses, dict):
         pass
       else:
-        raise TypeError(
-          'body_out[1] must be a tensor, list or dict: got %s' % str(losses))
+        losses = {"extra": tf.reduce_mean(losses)}
     else:
       output = body_out
       losses = {"extra": 0.0}

--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -1691,8 +1691,15 @@ class T2TModel(base.Layer):
   def _normalize_body_output(self, body_out):
     if isinstance(body_out, tuple):
       output, losses = body_out
-      if not isinstance(losses, dict):
+      if isinstance(losses, list):
+        losses = {"extra": tf.add_n([tf.reduce_mean(l) for l in losses])}
+      elif isinstance(losses, tf.Tensor):
         losses = {"extra": tf.reduce_mean(losses)}
+      elif isinstance(losses, dict):
+        pass
+      else:
+        raise TypeError(
+          'body_out[1] must be a tensor, list or dict: got %s' % str(losses))
     else:
       output = body_out
       losses = {"extra": 0.0}


### PR DESCRIPTION
… is a list

I believe this is the intended behaviour, but it may result in some changes to existing models where each loss returned in `body` was the same shape (in which case the `add_n` rather than `reduce_mean` will make the resulting loss `len(losses)` times larger.