### PR TITLE
Use TensorFlow 1.12 image on FloydHub

### DIFF
--- a/floyd.yml
+++ b/floyd.yml
@@ -1,2 +1,2 @@
-env: tensorflow-1.9
+env: tensorflow-1.12
 machine: gpu


### PR DESCRIPTION
FloydHub now has [support for TensorFlow 1.12](https://docs.floydhub.com/guides/tensorflow/#tensorflow-112) which is require for T2T to work correctly.