### PR TITLE
Update problem.py

### DIFF
--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -878,7 +878,7 @@ class Problem(object):
     dataset = tf.data.Dataset.from_tensor_slices(serialized_example)
     dataset = dataset.map(self.decode_example)
     dataset = dataset.map(lambda ex: self.preprocess_example(ex, mode, hparams))
-    dataset = dataset.map(self.maybe_reverse_and_copy)
+   
     dataset = dataset.map(data_reader.cast_ints_to_int32)
     dataset = dataset.padded_batch(
         tf.shape(serialized_example, out_type=tf.int64)[0],


### PR DESCRIPTION
[Error Querying Server: Requested more than 0 entries, but params is empty.](https://github.com/tensorflow/tensor2tensor/issues/1219) #1219
 After days of work, I have solved this problem. It caused by the function serving_input_fn. The input example no need to be reversed any more. So I deleted the code.