### PR TITLE
ML Engine: Improve logging

### DIFF
--- a/tensor2tensor/utils/cloud_mlengine.py
+++ b/tensor2tensor/utils/cloud_mlengine.py
@@ -390,3 +390,7 @@ def launch():
   launch_job(job_spec)
   tf.logging.info("Launched %s. See console to track: %s.", job_name,
                   CONSOLE_URL)
+  tf.logging.info("Interact with the training job from the command line:")
+  tf.logging.info("Abort job: gcloud ml-engine jobs cancel %s", job_name)
+  tf.logging.info("Stream logs: gcloud ml-engine jobs stream-logs %s", job_name)
+  tf.logging.info("Open tensorboard: tensorboard --logdir %s", train_dir)


### PR DESCRIPTION
This prints useful information on how to interact with the submitted job via the command line.

Example output:
```
INFO:tensorflow:Launched shake_shake_image_mnist_t2t_20190121_123909. See console to track: https://console.cloud.google.com/mlengine/jobs/.
INFO:tensorflow:Interact with the training job from the command line:
INFO:tensorflow:Abort job: gcloud ml-engine jobs cancel shake_shake_image_mnist_t2t_20190121_123909
INFO:tensorflow:Stream logs: gcloud ml-engine jobs stream-logs shake_shake_image_mnist_t2t_20190121_123909
INFO:tensorflow:Open tensorboard: tensorboard --logdir gs://lgeiger-test-bucket/training-test
```