### PR TITLE
added optimizer registry

### DIFF
--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -157,7 +157,7 @@ def adam_w(learning_rate, hparams):
       epsilon=hparams.optimizer_adam_epsilon)
 
 
-@registry.register_optimizer('adafactor')
+@registry.register_optimizer('Adafactor')
 def register_adafactor(learning_rate, hparams):
   return adafactor.adafactor_optimizer_from_hparams(hparams, learning_rate)
 

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -18,12 +18,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 import numpy as np
+import functools
 
 from tensor2tensor.layers import common_layers
 from tensor2tensor.utils import adafactor
 from tensor2tensor.utils import mlperf_log
 from tensor2tensor.utils import multistep_optimizer
 from tensor2tensor.utils import yellowfin
+from tensor2tensor.utils import registry
 
 import tensorflow as tf
 
@@ -93,6 +95,82 @@ def optimize(loss, learning_rate, hparams, use_tpu=False, variables=None):
   return train_op
 
 
+@registry.register_optimizer
+def adam(learning_rate, hparams):
+  # We change the default epsilon for Adam.
+  # Using LazyAdam as it's much faster for large vocabulary embeddings.
+  return tf.contrib.opt.LazyAdamOptimizer(
+      learning_rate,
+      beta1=hparams.optimizer_adam_beta1,
+      beta2=hparams.optimizer_adam_beta2,
+      epsilon=hparams.optimizer_adam_epsilon)
+
+
+@registry.register_optimizer
+def multistep_adam(learning_rate, hparams):
+  return multistep_optimizer.MultistepAdamOptimizer(
+      learning_rate,
+      beta1=hparams.optimizer_adam_beta1,
+      beta2=hparams.optimizer_adam_beta2,
+      epsilon=hparams.optimizer_adam_epsilon,
+      n=hparams.optimizer_multistep_accumulate_steps)
+
+
+@registry.register_optimizer
+def momentum(learning_rate, hparams):
+  return tf.train.MomentumOptimizer(
+      learning_rate,
+      momentum=hparams.optimizer_momentum_momentum,
+      use_nesterov=hparams.optimizer_momentum_nesterov)
+
+
+@registry.register_optimizer
+def yellow_fin(learning_rate, hparams):
+  return yellowfin.YellowFinOptimizer(
+      learning_rate=learning_rate,
+      momentum=hparams.optimizer_momentum_momentum)
+
+
+@registry.register_optimizer
+def true_adam(learning_rate, hparams):
+  return tf.train.AdamOptimizer(
+      learning_rate,
+      beta1=hparams.optimizer_adam_beta1,
+      beta2=hparams.optimizer_adam_beta2,
+      epsilon=hparams.optimizer_adam_epsilon)
+
+
+@registry.register_optimizer
+def adam_w(learning_rate, hparams):
+  # Openai gpt used weight decay.
+  # Given the internals of AdamW, weight decay dependent on the
+  # learning rate is chosen to match the openai implementation.
+  # The weight decay update to each parameter is applied before the adam
+  # gradients computation, which is different from that described
+  # in the paper and in the openai implementation:
+  # https://arxiv.org/pdf/1711.05101.pdf
+  return tf.contrib.opt.AdamWOptimizer(
+      0.01*learning_rate,
+      learning_rate,
+      beta1=hparams.optimizer_adam_beta1,
+      beta2=hparams.optimizer_adam_beta2,
+      epsilon=hparams.optimizer_adam_epsilon)
+
+
+@registry.register_optimizer('adafactor')
+def register_adafactor(learning_rate, hparams):
+  return adafactor.adafactor_optimizer_from_hparams(hparams, learning_rate)
+
+
+def _get_opt(learning_rate, hparams, key):
+  return tf.contrib.layers.OPTIMIZER_CLS_NAMES[key](learning_rate)
+
+
+for k in tf.contrib.layers.OPTIMIZER_CLS_NAMES:
+  if k not in registry._OPTIMIZERS:
+    registry.register_optimizer(k)(functools.partial(_get_opt, key=k))
+
+
 class ConditionalOptimizer(tf.train.Optimizer):
   """Conditional optimizer."""
 
@@ -113,53 +191,7 @@ class ConditionalOptimizer(tf.train.Optimizer):
         value=hparams.optimizer_adam_epsilon,
         hparams=hparams)
 
-    if optimizer_name == "Adam":
-      # We change the default epsilon for Adam.
-      # Using LazyAdam as it's much faster for large vocabulary embeddings.
-      self._opt = tf.contrib.opt.LazyAdamOptimizer(
-          lr,
-          beta1=hparams.optimizer_adam_beta1,
-          beta2=hparams.optimizer_adam_beta2,
-          epsilon=hparams.optimizer_adam_epsilon)
-    elif optimizer_name == "MultistepAdam":
-      self._opt = multistep_optimizer.MultistepAdamOptimizer(
-          lr,
-          beta1=hparams.optimizer_adam_beta1,
-          beta2=hparams.optimizer_adam_beta2,
-          epsilon=hparams.optimizer_adam_epsilon,
-          n=hparams.optimizer_multistep_accumulate_steps)
-    elif optimizer_name == "Momentum":
-      self._opt = tf.train.MomentumOptimizer(
-          lr,
-          momentum=hparams.optimizer_momentum_momentum,
-          use_nesterov=hparams.optimizer_momentum_nesterov)
-    elif optimizer_name == "YellowFin":
-      self._opt = yellowfin.YellowFinOptimizer(
-          learning_rate=lr, momentum=hparams.optimizer_momentum_momentum)
-    elif optimizer_name == "TrueAdam":
-      self._opt = tf.train.AdamOptimizer(
-          lr,
-          beta1=hparams.optimizer_adam_beta1,
-          beta2=hparams.optimizer_adam_beta2,
-          epsilon=hparams.optimizer_adam_epsilon)
-    elif optimizer_name == "AdamW":
-      # Openai gpt used weight decay.
-      # Given the internals of AdamW, weight decay dependent on the
-      # learning rate is chosen to match the openai implementation.
-      # The weight decay update to each parameter is applied before the adam
-      # gradients computation, which is different from that described
-      # in the paper and in the openai implementation:
-      # https://arxiv.org/pdf/1711.05101.pdf
-      self._opt = tf.contrib.opt.AdamWOptimizer(
-          0.01*lr,
-          lr,
-          beta1=hparams.optimizer_adam_beta1,
-          beta2=hparams.optimizer_adam_beta2,
-          epsilon=hparams.optimizer_adam_epsilon)
-    elif optimizer_name == "Adafactor":
-      self._opt = adafactor.adafactor_optimizer_from_hparams(hparams, lr)
-    else:
-      self._opt = tf.contrib.layers.OPTIMIZER_CLS_NAMES[optimizer_name](lr)
+    self._opt = registry.optimizer(optimizer_name)(lr, hparams)
     if _mixed_precision_is_enabled(hparams):
       if not hparams.mixed_precision_optimizer_loss_scaler:
         tf.logging.warning("Using mixed precision without a loss scaler will "

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -157,7 +157,7 @@ def adam_w(learning_rate, hparams):
       epsilon=hparams.optimizer_adam_epsilon)
 
 
-@registry.register_optimizer('Adafactor')
+@registry.register_optimizer("Adafactor")
 def register_adafactor(learning_rate, hparams):
   return adafactor.adafactor_optimizer_from_hparams(hparams, learning_rate)
 

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 import numpy as np
-import functools
 
 from tensor2tensor.layers import common_layers
 from tensor2tensor.utils import adafactor
@@ -162,13 +161,14 @@ def register_adafactor(learning_rate, hparams):
   return adafactor.adafactor_optimizer_from_hparams(hparams, learning_rate)
 
 
-def _get_opt(learning_rate, hparams, key):
-  return tf.contrib.layers.OPTIMIZER_CLS_NAMES[key](learning_rate)
+def _register_base_optimizer(key, fn):
+  registry.register_optimizer(key)(
+      lambda learning_rate, hparams: fn(learning_rate))
 
 
 for k in tf.contrib.layers.OPTIMIZER_CLS_NAMES:
   if k not in registry._OPTIMIZERS:
-    registry.register_optimizer(k)(functools.partial(_get_opt, key=k))
+    _register_base_optimizer(k, tf.contrib.layers.OPTIMIZER_CLS_NAMES[k])
 
 
 class ConditionalOptimizer(tf.train.Optimizer):

--- a/tensor2tensor/utils/registry.py
+++ b/tensor2tensor/utils/registry.py
@@ -126,12 +126,11 @@ _OPTIMIZERS = {}
 def register_optimizer(name=None):
   """Register an optimizer. name defaults to upper camel case of fn name."""
 
-  def decorator(opt_fn, registration_name=None):
+  def decorator(opt_fn, registration_name):
     """Registers and returns optimizer_fn with registration_name or default."""
-    opt_name = registration_name or misc_utils.snakecase_to_camelcase(
-        default_name(opt_fn)).title()
-    if opt_name in _OPTIMIZERS and not tf.executing_eagerly():
-      raise LookupError("Optimizer %s already registered." % opt_name)
+
+    if registration_name in _OPTIMIZERS and not tf.executing_eagerly():
+      raise LookupError("Optimizer %s already registered." % registration_name)
     if isinstance(opt_fn, functools.partial):
       partial_args = opt_fn.args
       partial_kwargs = opt_fn.keywords
@@ -146,12 +145,14 @@ def register_optimizer(name=None):
       raise ValueError("Optimizer registration function must take two "
                        "arguments: learning_rate (float) and "
                        "hparams (HParams).")
-    _OPTIMIZERS[opt_name] = opt_fn
+    _OPTIMIZERS[registration_name] = opt_fn
     return opt_fn
 
   if callable(name):
     opt_fn = name
-    return decorator(opt_fn, registration_name=default_name(opt_fn))
+    registration_name = misc_utils.snakecase_to_camelcase(
+        default_name(opt_fn)).title()
+    return decorator(opt_fn, registration_name=registration_name)
 
   return lambda opt_fn: decorator(opt_fn, name)
 


### PR DESCRIPTION
Added optimizer registration, similar to other registration methods. This allows users to add new optimizers in their `t2t_usr_dir` without having to manipulate tensor2tensor code directly.

EDIT: points below [resolved](https://github.com/tensorflow/tensor2tensor/pull/1401/commits/4d1b88f9842a099b2d4f02ecb8548d74bacabcd9)
Error checking number of args in registered function is a bit gross (`inspect` doesn't play nicely with `functools.partial`), but unsure of a better way of handling this.

I'm not convinced the way of handling optimizers in `tf.contrib.layers.OPTIMIZER_CLS_NAMES` is optimal, but I don't have a better way to bind loop variables to function calls.