### PR TITLE
Rewrites universal_transformer_base based on transformer_base

### DIFF
--- a/tensor2tensor/models/research/universal_transformer.py
+++ b/tensor2tensor/models/research/universal_transformer.py
@@ -438,14 +438,21 @@ def update_hparams_for_universal_transformer(hparams):
 
 @registry.register_hparams
 def universal_transformer_base():
-  hparams = transformer.transformer_big()
+  hparams = transformer.transformer_base()
+  # To have a similar capacity to the transformer_base with 6 layers,
+  # we need to increase the size of the UT's layer
+  # since, in fact, UT has a single layer repeating multiple times.
+  hparams.hidden_size = 1024
+  hparams.filter_size = 4096
+  hparams.num_heads = 16
+  hparams.layer_prepostprocess_dropout = 0.3
   hparams = update_hparams_for_universal_transformer(hparams)
   return hparams
 
 
 @registry.register_hparams
 def universal_transformer_base_tpu():
-  hparams = transformer.transformer_big()
+  hparams = universal_transformer_base()
   hparams = update_hparams_for_universal_transformer(hparams)
   transformer.update_hparams_for_tpu(hparams)
   hparams.add_step_timing_signal = False
@@ -454,7 +461,7 @@ def universal_transformer_base_tpu():
 
 @registry.register_hparams
 def universal_transformer_big():
-  hparams = transformer.transformer_big()
+  hparams = universal_transformer_base()
   hparams = update_hparams_for_universal_transformer(hparams)
   hparams.hidden_size = 2048
   hparams.filter_size = 8192


### PR DESCRIPTION
We need universal_transformer_base to have a similar capacity to transformer_base, which means, we need a larger size for the hidden states since there is a single layer in UT. Using transformer_big hparams, we had a UT with an approximately similar number of trainable parameters to transformer_base. 

Apparently, [the default batch size in transformer_big has been reduced to 2048 from 4096 to be able to train the model on a GPU  with 12 GB memory](https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/models/transformer.py#L1576), while we don't want this change in universal_transformer_base. In order to have the same setup we use in the paper (```batch_size = 4096```), I change the universal_transformer_base to use transformer_base hparams instead of universal_transformer_big, which I assume is more stable.