### PR TITLE
Add evolved transformer paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,5 +484,6 @@ T2T](https://research.googleblog.com/2017/06/accelerating-deep-learning-research
 * [Adafactor: Adaptive Learning Rates with Sublinear Memory Cost](https://arxiv.org/abs/1804.04235)
 * [Universal Transformers](https://arxiv.org/abs/1807.03819)
 * [Attending to Mathematical Language with Transformers](https://arxiv.org/abs/1812.02825)
+* [The Evolved Transformer](https://arxiv.org/abs/1901.11117)
 
 *Note: This is not an official Google product.*

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -484,5 +484,6 @@ T2T](https://research.googleblog.com/2017/06/accelerating-deep-learning-research
 * [Adafactor: Adaptive Learning Rates with Sublinear Memory Cost](https://arxiv.org/abs/1804.04235)
 * [Universal Transformers](https://arxiv.org/abs/1807.03819)
 * [Attending to Mathematical Language with Transformers](https://arxiv.org/abs/1812.02825)
+* [The Evolved Transformer](https://arxiv.org/abs/1901.11117)
 
 *Note: This is not an official Google product.*


### PR DESCRIPTION
Hi,

thanks for integrating the Evolved Transformer into `tensor2tensor` (f7c64216cb3013331e45dbc35b51f79010370b3e and 9626aff2f5b9ce9ca03aa576811af550e3c5ccff) :heart: 

This PR adds the [relevant paper](https://arxiv.org/abs/1901.11117) to the doc section.