### PR TITLE
Travis: Allow failures for tf@1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,8 @@ env:
     - TF_VERSION="1.12.*"
     - TF_VERSION="tf-nightly"
 matrix:
-  exclude:
-    # We test against all versions in Python 2 but only the latest stable
-    # version in Python 3
-    - python: "3.6"
-      env: TF_VERSION="tf-nightly"
+  allow_failures:
+    - env: TF_VERSION=$TF_LATEST
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libhdf5-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 language: python
+cache: pip
 git:
   depth: 1
   quiet: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: python
 git:
-  depth: 10
+  depth: 1
   quiet: true
 services:
   - docker
@@ -24,9 +24,6 @@ env:
 matrix:
   allow_failures:
     - env: TF_VERSION=$TF_LATEST
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libhdf5-dev
 install:
   - ./oss_scripts/oss_pip_install.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ env:
     - BOTO_CONFIG=/dev/null
   matrix:
     # We test against the latest stable TensorFlow and tf-nightly.
-    # If updating, also update TF_LATEST above
+    # If updating, also update TF_LATEST above and allow_failures
     - TF_VERSION="1.12.*"
     - TF_VERSION="tf-nightly"
 matrix:
   allow_failures:
-    - env: TF_VERSION=$TF_LATEST
+    - env: TF_VERSION="1.12.*"
 install:
   - ./oss_scripts/oss_pip_install.sh
 script:

--- a/oss_scripts/oss_pip_install.sh
+++ b/oss_scripts/oss_pip_install.sh
@@ -5,6 +5,10 @@ set -e  # fail and exit on any command erroring
 
 : "${TF_VERSION:?}"
 
+# Make sure we have the latest version of numpy - avoid problems we were
+# seeing with Python 3
+pip install -q -U numpy
+
 if [[ "$TF_VERSION" == "tf-nightly"  ]]
 then
   pip install tf-nightly;
@@ -21,7 +25,3 @@ t2t-datagen 2>&1 | grep translate_ende 2>&1 >/dev/null && echo passed
 pip install -q -e .[tests,allen]
 # Make sure to install the atari extras for gym
 pip install "gym[atari]"
-
-# Make sure we have the latest version of numpy - avoid problems we were
-# seeing with Python 3
-pip install -q -U numpy


### PR DESCRIPTION
If I recall correctly Google internally develops against `tf-nightly`. This results in failing builds when testing against the latest stable version of Tensorflow (currently all builds fail).

This PR adds Python 3 tests for `tf-nightly` and allows failures when testing against Tensorflow 1.12.

I think this would make it easier to merge PRs and quickly see the relevant failures.