### PR TITLE
Replace .append loop with list comprehension

### DIFF
--- a/tensor2tensor/data_generators/cnn_dailymail.py
+++ b/tensor2tensor/data_generators/cnn_dailymail.py
@@ -118,9 +118,7 @@ def example_splits(url_file, all_files):
 
   all_files_map = {f.split("/")[-1]: f for f in all_files}
 
-  urls = []
-  for line in tf.gfile.Open(url_file):
-    urls.append(line.strip().encode("utf-8"))
+  urls = [line.strip().encode("utf-8") for line in tf.gfile.Open(url_file)]
 
   filelist = []
   for url in urls:

--- a/tensor2tensor/data_generators/multi_problem_v2.py
+++ b/tensor2tensor/data_generators/multi_problem_v2.py
@@ -370,9 +370,8 @@ def epoch_rates_to_pmf(problems, epoch_rates=None):
   """
   if epoch_rates is None:
     epoch_rates = [1.0] * len(problems)
-  example_rates = []
-  for p, epoch_rate in zip(problems, epoch_rates):
-    example_rates.append(epoch_rate * p.num_training_examples)
+  example_rates = [epoch_rate * p.num_training_examples
+                   for p, epoch_rate in zip(problems, epoch_rates)]
   return example_rates_to_pmf(example_rates)
 
 

--- a/tensor2tensor/data_generators/video_utils.py
+++ b/tensor2tensor/data_generators/video_utils.py
@@ -45,13 +45,8 @@ flags.DEFINE_bool(
 
 
 def resize_video_frames(images, size):
-  resized_images = []
-  for image in images:
-    resized_images.append(
-        tf.to_int64(
-            tf.image.resize_images(image, [size, size],
-                                   tf.image.ResizeMethod.BILINEAR)))
-  return resized_images
+  return [tf.to_int64(tf.image.resize_images(
+      image, [size, size], tf.image.ResizeMethod.BILINEAR)) for image in images]
 
 
 def video_augmentation(features, hue=False, saturate=False, contrast=False):

--- a/tensor2tensor/envs/env_problem.py
+++ b/tensor2tensor/envs/env_problem.py
@@ -256,13 +256,11 @@ class EnvProblem(Env, problem.Problem):
     assert batch_size >= 1
     self._batch_size = batch_size
 
-    self._envs = []
-    for _ in range(batch_size):
-      self._envs.append(
-          gym_utils.make_gym_env(
-              self.base_env_name,
-              rl_env_max_episode_steps=max_episode_steps,
-              maxskip_env=max_and_skip_env))
+    self._envs = [
+        gym_utils.make_gym_env(
+            self.base_env_name,
+            rl_env_max_episode_steps=max_episode_steps,
+            maxskip_env=max_and_skip_env) for _ in range(batch_size)]
 
     # If self.observation_space and self.action_space aren't None, then it means
     # that this is a re-initialization of this class, in that case make sure

--- a/tensor2tensor/insights/server.py
+++ b/tensor2tensor/insights/server.py
@@ -145,13 +145,11 @@ def main(_):
     Returns:
       JSON for the supported models.
     """
-    configuration_list = []
-    for source_code, target_code, label in processors:
-      configuration_list.append({
-          "id": label,
-          "source_language": languages[source_code],
-          "target_language": languages[target_code],
-      })
+    configuration_list = [{
+        "id": label,
+        "source_language": languages[source_code],
+        "target_language": languages[target_code],
+        } for source_code, target_code, label in processors]
     return jsonify({
         "configuration": configuration_list
     })

--- a/tensor2tensor/layers/discretization.py
+++ b/tensor2tensor/layers/discretization.py
@@ -235,9 +235,8 @@ def bit_to_int(x_bit, num_bits, base=2):
     Integer representation of this number.
   """
   x_l = tf.stop_gradient(tf.to_int32(tf.reshape(x_bit, [-1, num_bits])))
-  x_labels = []
-  for i in range(num_bits):
-    x_labels.append(x_l[:, i] * tf.to_int32(base)**tf.to_int32(i))
+  x_labels = [
+      x_l[:, i] * tf.to_int32(base)**tf.to_int32(i) for i in range(num_bits)]
   res = sum(x_labels)
   return tf.to_int32(tf.reshape(res, common_layers.shape_list(x_bit)[:-1]))
 
@@ -254,12 +253,9 @@ def int_to_bit(x_int, num_bits, base=2):
     Corresponding number expressed in base.
   """
   x_l = tf.to_int32(tf.expand_dims(x_int, axis=-1))
-  x_labels = []
-  for i in range(num_bits):
-    x_labels.append(
-        tf.floormod(
-            tf.floordiv(tf.to_int32(x_l),
-                        tf.to_int32(base)**i), tf.to_int32(base)))
+  x_labels = [tf.floormod(
+      tf.floordiv(tf.to_int32(x_l), tf.to_int32(base)**i), tf.to_int32(base))
+      for i in range(num_bits)]
   res = tf.concat(x_labels, axis=-1)
   return tf.to_float(res)
 

--- a/tensor2tensor/layers/vq_discrete.py
+++ b/tensor2tensor/layers/vq_discrete.py
@@ -158,9 +158,8 @@ class DiscreteBottleneck(object):
         Integer representation of this number.
     """
     x_l = tf.stop_gradient(tf.to_int32(tf.reshape(x_bit, [-1, num_bits])))
-    x_labels = []
-    for i in range(num_bits):
-      x_labels.append(x_l[:, i] * tf.to_int32(base)**tf.to_int32(i))
+    x_labels = [
+        x_l[:, i] * tf.to_int32(base)**tf.to_int32(i) for i in range(num_bits)]
     res = sum(x_labels)
     return tf.to_int32(tf.reshape(res, common_layers.shape_list(x_bit)[:-1]))
 
@@ -177,12 +176,11 @@ class DiscreteBottleneck(object):
         Corresponding number expressed in base.
     """
     x_l = tf.to_int32(tf.expand_dims(x_int, axis=-1))
-    x_labels = []
-    for i in range(num_bits):
-      x_labels.append(
-          tf.floormod(
-              tf.floordiv(tf.to_int32(x_l),
-                          tf.to_int32(base)**i), tf.to_int32(base)))
+    x_labels = [
+        tf.floormod(
+            tf.floordiv(tf.to_int32(x_l),
+                        tf.to_int32(base)**i), tf.to_int32(base))
+        for i in range(num_bits)]
     res = tf.concat(x_labels, axis=-1)
     return tf.to_float(res)
 

--- a/tensor2tensor/models/video/base.py
+++ b/tensor2tensor/models/video/base.py
@@ -303,10 +303,9 @@ class NextFrameBase(t2t_model.T2TModel):
     def sample():
       """Calculate the scheduled sampling params based on iteration number."""
       with tf.variable_scope("scheduled_sampling", reuse=tf.AUTO_REUSE):
-        output_items = []
-        for item_gt, item_gen in zip(groundtruth_items, generated_items):
-          output_items.append(scheduled_sampling_func(item_gt, item_gen))
-        return output_items
+        return [
+            scheduled_sampling_func(item_gt, item_gen)
+            for item_gt, item_gen in zip(groundtruth_items, generated_items)]
 
     cases = [
         (tf.logical_not(done_warm_start), lambda: groundtruth_items),

--- a/tensor2tensor/rl/player.py
+++ b/tensor2tensor/rl/player.py
@@ -177,12 +177,9 @@ class PlayerEnv(gym.Env):
     keys_to_action = {}
 
     for action_id, action_meaning in enumerate(self.action_meanings):
-      keys = []
-      for keyword, key in keyword_to_key.items():
-        if keyword in action_meaning:
-          keys.append(key)
-      keys_tuple = tuple(sorted(keys))
-      del keys
+      keys_tuple = tuple(sorted([
+          key for keyword, key in keyword_to_key.items()
+          if keyword in action_meaning]))
       assert keys_tuple not in keys_to_action
       keys_to_action[keys_tuple] = action_id
 

--- a/tensor2tensor/utils/data_reader.py
+++ b/tensor2tensor/utils/data_reader.py
@@ -300,9 +300,7 @@ def _pad_batch(features, batch_multiple):
   padded_features = {}
   for k, feature in features.items():
     rank = len(feature.shape)
-    paddings = []
-    for _ in range(rank):
-      paddings.append([0, 0])
+    paddings = [[0, 0] for _ in range(rank)]
     paddings[0][1] = batch_padding
     padded_feature = tf.pad(feature, paddings)
     padded_features[k] = padded_feature

--- a/tensor2tensor/visualization/attention.py
+++ b/tensor2tensor/visualization/attention.py
@@ -135,11 +135,7 @@ def _get_attention(inp_text, out_text, enc_atts, dec_atts, encdec_atts):
 
   def get_attentions(get_attention_fn):
     num_layers = len(enc_atts)
-    attentions = []
-    for i in range(num_layers):
-      attentions.append(get_attention_fn(i))
-
-    return attentions
+    return [get_attention_fn(i) for i in range(num_layers)]
 
   attentions = {
       'all': {


### PR DESCRIPTION
This PR replaces loops that only append to a list with list comprehensions. This makes it more concise and (arguably) more readably.

List comprehensions also are quite a bit faster than appending to a list. Toy example in Python 3.6:
```python
In [1]: %%timeit
   ...: l = []
   ...: for i in range(5000):
   ...:     l.append(i)
375 µs ± 1.73 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [2]: %%timeit
   ...: l = [i for i in range(5000)]
168 µs ± 1.08 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```