### PR TITLE
Prefer literals over list and dict functions

### DIFF
--- a/tensor2tensor/data_generators/audio.py
+++ b/tensor2tensor/data_generators/audio.py
@@ -60,7 +60,7 @@ def _collect_data(directory, input_ext, target_ext):
   #   if the datafile was "/path/to/datafile.wav" then the key would be
   #   "/path/to/datafile"
   # value: a pair of strings (input_filepath, target_filepath)
-  data_files = dict()
+  data_files = {}
   for root, _, filenames in os.walk(directory):
     input_files = [filename for filename in filenames if input_ext in filename]
     for input_filename in input_files:

--- a/tensor2tensor/data_generators/gym_env.py
+++ b/tensor2tensor/data_generators/gym_env.py
@@ -640,7 +640,7 @@ class T2TGymEnv(T2TEnv):
 
     if self.should_derive_observation_space:
       with self._tf_graph.obj.as_default():
-        self._resize = dict()
+        self._resize = {}
         orig_height, orig_width = orig_observ_space.shape[:2]
         self._img_batch_t = _Noncopyable(tf.placeholder(
             dtype=tf.uint8, shape=(None, orig_height, orig_width, 3)))

--- a/tensor2tensor/data_generators/gym_env_test.py
+++ b/tensor2tensor/data_generators/gym_env_test.py
@@ -84,8 +84,8 @@ class GymEnvTest(tf.test.TestCase):
   def init_batch_and_play(self, env_name, steps_per_epoch=1, epochs=(0,),
                           generate_data=False, batch_size=2, **kwargs):
     env = gym_env.T2TGymEnv(env_name, batch_size=batch_size, **kwargs)
-    obs = list()
-    rewards = list()
+    obs = []
+    rewards = []
     num_dones = 0
     for epoch in epochs:
       env.start_new_epoch(epoch, self.out_dir)
@@ -100,8 +100,8 @@ class GymEnvTest(tf.test.TestCase):
     return env, obs, rewards, num_dones
 
   def play(self, env, n_steps):
-    obs = list()
-    rewards = list()
+    obs = []
+    rewards = []
     obs.append(env.reset())
     num_dones = 0
     for _ in range(n_steps):

--- a/tensor2tensor/data_generators/librispeech.py
+++ b/tensor2tensor/data_generators/librispeech.py
@@ -67,7 +67,7 @@ def _collect_data(directory, input_ext, transcription_ext):
   #   if the datafile was "/path/to/datafile.wav" then the key would be
   #   "/path/to/datafile"
   # value: a pair of strings (media_filepath, label)
-  data_files = dict()
+  data_files = {}
   for root, _, filenames in os.walk(directory):
     transcripts = [filename for filename in filenames
                    if transcription_ext in filename]

--- a/tensor2tensor/data_generators/mscoco.py
+++ b/tensor2tensor/data_generators/mscoco.py
@@ -107,7 +107,7 @@ def mscoco_generator(data_dir,
   caption_file = io.open(caption_filepath)
   caption_json = json.load(caption_file)
   # Dictionary from image_id to ((filename, height, width), captions).
-  image_dict = dict()
+  image_dict = {}
   for image in caption_json["images"]:
     image_dict[image["id"]] = [(image["file_name"], image["height"],
                                 image["width"]), []]

--- a/tensor2tensor/models/research/attention_lm_moe.py
+++ b/tensor2tensor/models/research/attention_lm_moe.py
@@ -308,7 +308,7 @@ class AttentionLmMoe(t2t_model.T2TModel):
                 x,
                 hparams.filter_size)
           else:
-            additional_conv_params = dict()
+            additional_conv_params = {}
             if hparams.use_sepconv:
               additional_conv_params = dict(
                   padding="LEFT",

--- a/tensor2tensor/rl/player_utils.py
+++ b/tensor2tensor/rl/player_utils.py
@@ -389,7 +389,7 @@ def infer_paths(output_dir, **subdirs):
   Returns:
     a dictionary with the directories.
   """
-  directories = dict()
+  directories = {}
   for name, path in six.iteritems(subdirs):
     directories[name] = path if path else os.path.join(output_dir, name)
   directories["output_dir"] = output_dir

--- a/tensor2tensor/utils/hparam.py
+++ b/tensor2tensor/utils/hparam.py
@@ -495,7 +495,7 @@ class HParams(object):
       ValueError: If `values` cannot be parsed or a hyperparameter in `values`
       doesn't exist.
     """
-    type_map = dict()
+    type_map = {}
     for name, t in self._hparam_types.items():
       param_type, _ = t
       type_map[name] = param_type

--- a/tensor2tensor/utils/metrics.py
+++ b/tensor2tensor/utils/metrics.py
@@ -599,7 +599,7 @@ def create_evaluation_metrics(problems, model_hparams):
   def weights_fn_for_mp(problem_task_id):
     return lambda x: common_layers.weights_multi_problem(x, problem_task_id)
 
-  eval_metrics = dict()
+  eval_metrics = {}
   for problem_instance in problems:
     problem_name = problem_instance.name
     if problem_instance.was_reversed:
@@ -675,7 +675,7 @@ def create_eager_metrics_internal(metric_fns,
     (accum_fn(predictions, targets) => None,
      result_fn() => dict<str metric_name, float avg_val>
   """
-  tfe_metrics = dict()
+  tfe_metrics = {}
 
   for name in metric_fns:
     tfe_metrics[name] = tfe.metrics.Mean(name=name)

--- a/tensor2tensor/utils/rouge.py
+++ b/tensor2tensor/utils/rouge.py
@@ -62,7 +62,7 @@ def _lcs(x, y):
     Table of dictionary of coord and len lcs
   """
   n, m = len(x), len(y)
-  table = dict()
+  table = {}
   for i in range(n + 1):
     for j in range(m + 1):
       if i == 0 or j == 0:

--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -1333,7 +1333,7 @@ class T2TModel(base.Layer):
     return samples, logits, losses
 
   def _shard_features(self, features):  # pylint: disable=missing-docstring
-    sharded_features = dict()
+    sharded_features = {}
     for k, v in sorted(six.iteritems(features)):
       v = tf.convert_to_tensor(v)
       v_shape = common_layers.shape_list(v)


### PR DESCRIPTION
This is just some search and replace to improve readability:
- `d = dict()` --> `d = {}`
- `l = list()` --> `l = []`

Some nice benefit of this is that literals in Python are quite a bit faster (though only 60 ns - 75 ns):
```shell
In [1]: %timeit d = dict()
101 ns ± 0.0829 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [2]: %timeit dl = {}
34.1 ns ± 0.378 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [3]: %timeit l = list()
101 ns ± 0.541 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [4]: %timeit l = []
25.4 ns ± 0.346 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```