### PR TITLE
[bugfix] - COCO dataset reads images as text files

### DIFF
--- a/tensor2tensor/data_generators/mscoco.py
+++ b/tensor2tensor/data_generators/mscoco.py
@@ -125,7 +125,7 @@ def mscoco_generator(data_dir,
   for image_info, labels in data:
     image_filename = image_info[0]
     image_filepath = os.path.join(tmp_dir, prefix, image_filename)
-    with tf.gfile.Open(image_filepath, "r") as f:
+    with tf.gfile.Open(image_filepath, "rb") as f:
       encoded_image_data = f.read()
       height, width = image_info[1], image_info[2]
       for label in labels:


### PR DESCRIPTION
After trying to run tensor2tensor on COCO dataset, I got error:
```
Traceback (most recent call last):
  [...]
  File "/root/.local/lib/python3.5/site-packages/tensor2tensor/bin/t2t_trainer.py", line 401, in <module>
    tf.app.run()
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/platform/app.py", line 125, in run
    _sys.exit(main(argv))
  File "/root/.local/lib/python3.5/site-packages/tensor2tensor/bin/t2t_trainer.py", line 384, in main
    generate_data()
  File "/root/.local/lib/python3.5/site-packages/tensor2tensor/bin/t2t_trainer.py", line 279, in generate_data
    registry.problem(problem_name).generate_data(data_dir, tmp_dir)
  File "/root/.local/lib/python3.5/site-packages/tensor2tensor/data_generators/image_utils.py", line 372, in generate_data
    self.dev_filepaths(data_dir, self.dev_shards, shuffled=False))
  File "/root/.local/lib/python3.5/site-packages/tensor2tensor/data_generators/generator_utils.py", line 490, in generate_dataset_and_shuffle
    generate_files(train_gen, train_paths)
  File "/root/.local/lib/python3.5/site-packages/tensor2tensor/data_generators/generator_utils.py", line 165, in generate_files
    for case in generator:
  File "/root/.local/lib/python3.5/site-packages/tensor2tensor/data_generators/mscoco.py", line 129, in mscoco_generator
    encoded_image_data = f.read()
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/lib/io/file_io.py", line 132, in read
    pywrap_tensorflow.ReadFromStream(self._read_buf, length, status))
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/lib/io/file_io.py", line 100, in _prepare_value
    return compat.as_str_any(val)
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/util/compat.py", line 107, in as_str_any
    return as_str(value)
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/util/compat.py", line 80, in as_text
    return bytes_or_text.decode(encoding)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
```

So my PR only changes to reading images as bytefiles.