### PR TITLE
Fix step size extraction for checkpoint name 

### DIFF
--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -956,7 +956,7 @@ def _decode_input_tensor_to_features_dict(feature_map, hparams):
 
 
 def get_step_from_ckpt_path(path):
-  return int(os.path.basename(path).split("-")[1])
+  return int(os.path.basename(path).split("-")[-1])
 
 
 def latest_checkpoint_step(ckpt_dir):


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/tensorflow/tensor2tensor/commit/47ced4eecd13974e3a690a80b1f60effda089fa9

 Fix step size extraction for checkpoint name with - in it such as avg-model.ckpt-1234