### PR TITLE
Upgrade ML Engine runtime to 1.13 and remove unused Gcloud class

### DIFF
--- a/tensor2tensor/data_generators/wikisum/parallel_launch.py
+++ b/tensor2tensor/data_generators/wikisum/parallel_launch.py
@@ -146,7 +146,7 @@ def create_instance(instance_name, cpu=1, mem=4):
 
 
 def list_vm_names_and_ips():
-  list_out = cloud.shell_output(cloud.Gcloud.LIST_VM)
+  list_out = cloud.shell_output(cloud.LIST_VM)
   lines = [l.split() for l in list_out.split("\n")[1:-1]]
   names_and_ips = [(l[0].strip(), l[-2].strip()) for l in lines]
   return names_and_ips

--- a/tensor2tensor/utils/cloud_mlengine.py
+++ b/tensor2tensor/utils/cloud_mlengine.py
@@ -35,55 +35,10 @@ import tensorflow as tf
 FLAGS = tf.flags.FLAGS
 
 CONSOLE_URL = "https://console.cloud.google.com/mlengine/jobs/"
-RUNTIME_VERSION = "1.12"
-
-
-class Gcloud(object):
-  """gcloud command strings."""
-  # Note these can be modified by set_versions
-  VM_VERSION = "tf-1-12"
-  TPU_VERSION = "1.12"
-
-  @classmethod
-  def set_versions(cls, vm, tpu):
-    cls.VM_VERSION = vm
-    cls.TPU_VERSION = tpu
-
-  @classmethod
-  def create_vm(cls):
-    create_vm_str = """
-    gcloud compute instances create {name} \
-      --machine-type=n1-standard-8 \
-      --image-family=%s \
-      --image-project=ml-images \
-      --scopes=https://www.googleapis.com/auth/cloud-platform
-    """ % cls.VM_VERSION
-    return create_vm_str
-
-  DELETE_VM = "gcloud compute instances delete {name} --quiet"
-
-  @classmethod
-  def create_tpu(cls):
-    create_tpu_str = """
-    gcloud beta compute tpus create \
-      {name} \
-      --range={tpu_ip}/29 \
-      --version=%s
-    """ % cls.TPU_VERSION
-    return create_tpu_str
-
-  DELETE_TPU = "gcloud beta compute tpus delete {name} --quiet"
-
-  LIST_TPU = "gcloud beta compute tpus list"
-  LIST_VM = "gcloud compute instances list"
-
-  SSH_LOCAL_PORT_FORWARD = "-L {local_port}:{host}:{remote_port}"
-  SSH_TUNNEL = """
-  gcloud compute ssh {name} -- -N
-  """
-
-  DEFAULT_PROJECT = "gcloud config get-value project"
-  DEFAULT_REGION = "gcloud config get-value compute/region"
+RUNTIME_VERSION = "1.13"
+LIST_VM = "gcloud compute instances list"
+DEFAULT_PROJECT = "gcloud config get-value project"
+DEFAULT_REGION = "gcloud config get-value compute/region"
 
 
 def shell_output(cmd_, **kwargs):
@@ -99,11 +54,11 @@ def format_cmd(cmd_, **kwargs):
 
 
 def default_region():
-  return shell_output(Gcloud.DEFAULT_REGION).strip()
+  return shell_output(DEFAULT_REGION).strip()
 
 
 def default_project():
-  return shell_output(Gcloud.DEFAULT_PROJECT).strip()
+  return shell_output(DEFAULT_PROJECT).strip()
 
 
 def get_setup_file(name, packages=None):


### PR DESCRIPTION
This PR upgrades the ML Engine runtime to 1.13 in order to fix #1472. Unfortunately ML Engine doesn't support TPUs in version 1.13 yet: https://cloud.google.com/ml-engine/docs/release-notes

This also removes the unused Gcloud class to clean up the code a bit.