### PR TITLE
Fix glow

### DIFF
--- a/tensor2tensor/models/research/glow.py
+++ b/tensor2tensor/models/research/glow.py
@@ -128,7 +128,8 @@ class Glow(t2t_model.T2TModel):
       init_features: initialization features.
     """
     train_dataset = self.hparams.problem.dataset(
-        tf.estimator.ModeKeys.TRAIN, hparams=self.hparams)
+        tf.estimator.ModeKeys.TRAIN, data_dir=self.hparams.data_dir,
+        hparams=self.hparams)
     train_dataset = train_dataset.batch(self.hparams.init_batch_size)
     train_dataset = self.init_preprocess(train_dataset)
     return train_dataset.make_one_shot_iterator().get_next()


### PR DESCRIPTION
Currently running `glow` fails with `assert data_dir`

This fixes the code to pass data_dir and make it run again.

It seems like this wasn't caught because the tests for glow are turned off. Perhaps it's worth turning those back on. I have them running locally again but not sure what the best way is to refer to a local cifar on the test systems (I now hardcode my local path to a prepared cifar):

```
diff --git a/tensor2tensor/models/research/glow_test.py b/tensor2tensor/models/research/glow_test.py
index 653b237..6c9cf46 100644
--- a/tensor2tensor/models/research/glow_test.py
+++ b/tensor2tensor/models/research/glow_test.py
@@ -48,11 +48,12 @@ class GlowModelTest(tf.test.TestCase):
       hparams.n_levels = 2
       hparams.init_batch_size = 256
       hparams.batch_size = 1
-      hparams.data_dir = ''
+      hparams.add_hparam('data_dir', 'data/')
       cifar_problem = problems.problem('image_cifar10_plain_random_shift')
       hparams.problem = cifar_problem
       model = glow.Glow(hparams, tf.estimator.ModeKeys.TRAIN)
-      train_dataset = cifar_problem.dataset(MODES.TRAIN)
+      train_dataset = cifar_problem.dataset(MODES.TRAIN,
+                                            data_dir=hparams.data_dir)
       one_shot = train_dataset.make_one_shot_iterator()
       x_batch, y_batch = self.batch(one_shot)
       features = {'inputs': x_batch, 'targets': y_batch}
@@ -77,7 +78,7 @@ class GlowModelTest(tf.test.TestCase):
     hparams = glow.glow_hparams()
     hparams.depth = 15
     hparams.n_levels = 2
-    hparams.data_dir = ''
+    hparams.add_hparam('data_dir', 'data/')
     curr_dir = tempfile.mkdtemp()
 
     # Training pipeline
@@ -85,7 +86,8 @@ class GlowModelTest(tf.test.TestCase):
       cifar_problem = problems.problem('image_cifar10_plain_random_shift')
       hparams.problem = cifar_problem
       model = glow.Glow(hparams, tf.estimator.ModeKeys.TRAIN)
-      train_dataset = cifar_problem.dataset(MODES.TRAIN)
+      train_dataset = cifar_problem.dataset(MODES.TRAIN,
+                                            data_dir=hparams.data_dir)
       one_shot = train_dataset.make_one_shot_iterator()
       x_batch, y_batch = self.batch(one_shot)
       features = {'inputs': x_batch, 'targets': y_batch}
@@ -109,7 +111,8 @@ class GlowModelTest(tf.test.TestCase):
       cifar_problem = problems.problem('image_cifar10_plain_random_shift')
       hparams.problem = cifar_problem
       model = glow.Glow(hparams, tf.estimator.ModeKeys.PREDICT)
-      test_dataset = cifar_problem.dataset(MODES.EVAL)
+      test_dataset = cifar_problem.dataset(MODES.EVAL,
+                                           data_dir=hparams.data_dir)
       one_shot = test_dataset.make_one_shot_iterator()
       x_batch, y_batch = self.batch(one_shot)
       features = {'inputs': x_batch, 'targets': y_batch}
```

