### PR TITLE
Fixed bug in _target_modality_is_real

### DIFF
--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -308,7 +308,7 @@ class T2TModel(base.Layer):
     modality_name = self._hparams.name.get(
         "targets",
         modalities.get_name(modality))(self._hparams, vocab_size)
-    return modality_name.startswith("Real")
+    return modality_name.startswith("real")
 
   def call(self, inputs, **kwargs):
     del kwargs


### PR DESCRIPTION
I was training a transformer model with a real-value output. I had my problems file set up properly, but when using `.infer` to load a trained model checkpoint and use it to run inference on some input, I was getting very obscure errors to do with tensor sizes. After some debugging it became apparent that the tensor2tensor framework was trying to look for a class to output, and did not accept that I wanted a real-valued output.

Turns out this is due to a small typo in t2t_model - when checking if the output modality is real, it decided it was not and this caused the decoder part of the library to use fast_decode rather than the slow version that seems suitable for real valued predictions. It checks if the output modality name begins with "Real_" to determine this.

Unfortunately, the name of these output modalities are things like `real_l2_loss_modality` with a lowercase r...

Hope this helps other people with the same issue!