### PR TITLE
Updated link to DeepMind Math dataset

### DIFF
--- a/tensor2tensor/data_generators/algorithmic_math_deepmind.py
+++ b/tensor2tensor/data_generators/algorithmic_math_deepmind.py
@@ -33,7 +33,7 @@ from tensor2tensor.utils import registry
 import tensorflow as tf
 
 
-_URL = "https://storage.googleapis.com/mathematics-dataset/v1.0.tar.gz"
+_URL = "https://storage.cloud.google.com/mathematics-dataset/mathematics_dataset-v1.0.tar.gz"
 
 
 @registry.register_problem


### PR DESCRIPTION
The url to the math dataset got updated.
Reference: https://github.com/deepmind/mathematics_dataset/issues/2