### PR TITLE
Loss twice multiplied with loss_coef

### DIFF
--- a/tensor2tensor/utils/expert_utils.py
+++ b/tensor2tensor/utils/expert_utils.py
@@ -1044,7 +1044,7 @@ def local_moe(x,
           noisy_gating=True,
           noise_epsilon=1e-2)
       importance = tf.reduce_sum(gates, 0)
-      loss = loss_coef * (cv_squared(importance) + cv_squared(load))
+      loss = (cv_squared(importance) + cv_squared(load))
     else:
       assert hparams.gating_type == "vq"
       tf.logging.info("Using VQ gating")


### PR DESCRIPTION
In the case of topk gating, the loss is falsely multiplied twice by the loss coefficient.