### PR TITLE
Adding automatic mixed precision support

### DIFF
--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -66,7 +66,7 @@ def optimize(loss, learning_rate, hparams, use_tpu=False, variables=None, gpu_au
   opt = ConditionalOptimizer(hparams.optimizer, learning_rate, hparams, use_tpu)
   if use_tpu:
     opt = tf.contrib.tpu.CrossShardOptimizer(opt)
-  if os.environ.get('GPU_AUTO_MIXED_PRECISION', default='0') == '1' or gpu_auto_mixed_precision:
+  if os.environ.get('TF_ENABLE_AUTO_MIXED_PRECISION', default='0') == '1' or gpu_auto_mixed_precision:
       if use_tpu:
           raise(RuntimeError("GPU auto mixed precision cannot be used with TPU"))
       elif _mixed_precision_is_enabled(hparams):

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -69,6 +69,8 @@ def optimize(loss, learning_rate, hparams, use_tpu=False, variables=None, gpu_au
   if os.environ.get('GPU_AUTO_MIXED_PRECISION', default=False) or gpu_auto_mixed_precision:
       if use_tpu:
           raise(RuntimeError("GPU auto mixed precision cannot be used with TPU"))
+      elif _mixed_precision_is_enabled(hparams):
+          raise(RuntimeError("GPU auto mixed precision cannot be used with manual mixed precision"))
       else:
           opt = tf.train.experimental.enable_mixed_precision_graph_rewrite(opt)
 

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -66,7 +66,7 @@ def optimize(loss, learning_rate, hparams, use_tpu=False, variables=None, gpu_au
   opt = ConditionalOptimizer(hparams.optimizer, learning_rate, hparams, use_tpu)
   if use_tpu:
     opt = tf.contrib.tpu.CrossShardOptimizer(opt)
-  if os.environ.get('GPU_AUTO_MIXED_PRECISION', default=False) or gpu_auto_mixed_precision:
+  if os.environ.get('GPU_AUTO_MIXED_PRECISION', default='0') == '1' or gpu_auto_mixed_precision:
       if use_tpu:
           raise(RuntimeError("GPU auto mixed precision cannot be used with TPU"))
       elif _mixed_precision_is_enabled(hparams):

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -73,6 +73,7 @@ def optimize(loss, learning_rate, hparams, use_tpu=False, variables=None, gpu_au
           raise(RuntimeError("GPU auto mixed precision cannot be used with manual mixed precision"))
       else:
           setattr(opt, '_use_locking', 'True')
+          setattr(opt, '_name', 'ConditionalOptimizer')
           opt = tf.train.experimental.enable_mixed_precision_graph_rewrite(opt)
 
   opt_summaries = []

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -72,6 +72,7 @@ def optimize(loss, learning_rate, hparams, use_tpu=False, variables=None, gpu_au
       elif _mixed_precision_is_enabled(hparams):
           raise(RuntimeError("GPU auto mixed precision cannot be used with manual mixed precision"))
       else:
+          setattr(opt, '_use_locking', 'True')
           opt = tf.train.experimental.enable_mixed_precision_graph_rewrite(opt)
 
   opt_summaries = []


### PR DESCRIPTION
Automatic Mixed Precision for Tensorflow has been recently introduced:
https://medium.com/tensorflow/automatic-mixed-precision-in-tensorflow-for-faster-ai-training-on-nvidia-gpus-6033234b2540

This PR adds automatic mixed precision training to all tensor2tensor models via setting a single OS flag:
```
export TF_ENABLE_AUTO_MIXED_PRECISION=1
```
Alternatively, it can also be enabled by directly calling the optimize() function with an appropriate parameter:
```
optimize(loss, learning_rate, hparams, use_tpu=False, variables=None, gpu_auto_mixed_precision=True)
```
Automatic (GPU) mixed precision should not be used with TPU and manual mixed precision. The PR checks for these cases.

We've tested speed impact on several models on 1x V100 16GB GPU:
Image classification - Resnet-50: 1.9x
Translate - Transformer-big: 1.9x
Sentiment analysis - Transformer-big: 1.4x