### PR TITLE
achieve the paper Attention Is All You Need's position encoding

### DIFF
--- a/tensor2tensor/layers/common_attention.py
+++ b/tensor2tensor/layers/common_attention.py
@@ -447,7 +447,10 @@ def get_timing_signal_1d(length,
   inv_timescales = min_timescale * tf.exp(
       tf.to_float(tf.range(num_timescales)) * -log_timescale_increment)
   scaled_time = tf.expand_dims(position, 1) * tf.expand_dims(inv_timescales, 0)
-  signal = tf.concat([tf.sin(scaled_time), tf.cos(scaled_time)], axis=1)
+  signals_to_concat = [tf.expand_dims(tf.sin(scaled_time), -1),
+                       tf.expand_dims(tf.cos(scaled_time), -1)]
+  signal = tf.concat(signals_to_concat, axis=-1)
+  signal = tf.reshape(signal, [length, channels])
   signal = tf.pad(signal, [[0, 0], [0, tf.mod(channels, 2)]])
   signal = tf.reshape(signal, [1, length, channels])
   return signal


### PR DESCRIPTION
as the paper Attention Is All You Need (https://arxiv.org/pdf/1706.03762.pdf) described, the position encoding was using sine and cosine function alternatively depending on the position's odevity. but the achievement in tensor2tensor just concated the sine and cosine which i think not right.