### PR TITLE
Refine automatic mixed precision support

### DIFF
--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -141,7 +141,9 @@ flags.DEFINE_string("job-dir", None,
 flags.DEFINE_integer("log_step_count_steps", 100,
                      "Number of local steps after which progress is printed "
                      "out")
-
+flags.DEFINE_bool("gpu_automatic_mixed_precision", False,
+                  "Whether to employ GPU automatic mixed precision training "
+                  "(via graph rewrite and dynamic loss scaling).")
 
 
 def set_hparams_from_args(args):

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -45,8 +45,7 @@ def optimize(loss,
              learning_rate,
              hparams,
              use_tpu=False,
-             variables=None,
-             gpu_auto_mixed_precision=False):
+             variables=None):
   """Minimize loss."""
   loss = weight_decay_and_noise(loss, hparams, learning_rate)
   loss = tf.identity(loss, name="total_loss")
@@ -71,7 +70,7 @@ def optimize(loss,
   opt = ConditionalOptimizer(hparams.optimizer, learning_rate, hparams, use_tpu)
   if use_tpu:
     opt = tf.contrib.tpu.CrossShardOptimizer(opt)
-  if hparams.gpu_automatic_mixed_precision:
+  if tf.flags.FLAGS.gpu_automatic_mixed_precision:
     if use_tpu:
       raise RuntimeError("GPU auto mixed precision cannot be used with TPU")
     elif _mixed_precision_is_enabled(hparams):

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
 import numpy as np
 from tensor2tensor.layers import common_layers
 from tensor2tensor.utils import adafactor as adafactor_lib

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -71,7 +71,7 @@ def optimize(loss,
   opt = ConditionalOptimizer(hparams.optimizer, learning_rate, hparams, use_tpu)
   if use_tpu:
     opt = tf.contrib.tpu.CrossShardOptimizer(opt)
-  if hparams.gpu_auto_mixed_precision:
+  if hparams.gpu_automatic_mixed_precision:
     if use_tpu:
       raise RuntimeError("GPU auto mixed precision cannot be used with TPU")
     elif _mixed_precision_is_enabled(hparams):

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -71,8 +71,7 @@ def optimize(loss,
   opt = ConditionalOptimizer(hparams.optimizer, learning_rate, hparams, use_tpu)
   if use_tpu:
     opt = tf.contrib.tpu.CrossShardOptimizer(opt)
-  if gpu_auto_mixed_precision or os.environ.get(
-      "TF_ENABLE_AUTO_MIXED_PRECISION", "0") == "1":
+  if hparams.gpu_auto_mixed_precision:
     if use_tpu:
       raise RuntimeError("GPU auto mixed precision cannot be used with TPU")
     elif _mixed_precision_is_enabled(hparams):


### PR DESCRIPTION
In continuation of  https://github.com/tensorflow/tensor2tensor/pull/1637

In this PR, we re-organize automatic mixed precision training support to provide a cleaner implementation and an easier interface. 

In particular, [GPU automatic mixed precision training](https://medium.com/tensorflow/automatic-mixed-precision-in-tensorflow-for-faster-ai-training-on-nvidia-gpus-6033234b2540) can now be enabled via setting the flag `--gpu_automatic_mixed_precision` for **all tensor2tensor models**, for example: 

**Transformer**
```
PROBLEM=translate_ende_wmt32k
MODEL=transformer
HPARAMS=transformer_big
DATA_DIR=/data/translate_ende_wmt32k
TRAIN_DIR=/tmp/$MODEL-$HPARAMS

t2t-trainer \
  --data_dir=$DATA_DIR \
  --problem=$PROBLEM \
  --model=$MODEL \
  --hparams_set=$HPARAMS \
  --output_dir=$TRAIN_DIR \
  --train_steps=100000 \
  --eval_steps=1000 \
  --gpu_automatic_mixed_precision=True
```

**Resnet:**
```
PROBLEM=image_imagenet224
MODEL=resnet
HPARAMS=resnet_50
DATA_DIR=/data/ImageNet
TRAIN_DIR=/tmp/$HPARAMS

t2t-trainer \
  --data_dir=$DATA_DIR \
  --problem=$PROBLEM \
  --model=$MODEL \
  --hparams_set=$HPARAMS \
  --output_dir=$TRAIN_DIR \
  --hparams='batch_size=256' \
  --worker_gpu=8 \
  --gpu_automatic_mixed_precision=True
```

This is opposed to the previous approaches of setting the OS flag `TF_ENABLE_AUTO_MIXED_PRECISION` which is a non-programatic approach, or passing the flag `gpu_auto_mixed_precision` directly to the optimizer (which will require modification of individual models to make call to optimizer with mixed precision training option). 