### PR TITLE
Refine automatic mixed precision support via hyper param

### DIFF
--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -141,7 +141,9 @@ flags.DEFINE_string("job-dir", None,
 flags.DEFINE_integer("log_step_count_steps", 100,
                      "Number of local steps after which progress is printed "
                      "out")
-
+flags.DEFINE_bool("gpu_automatic_mixed_precision", False,
+                  "Whether to employ GPU automatic mixed precision training "
+                  "(via graph rewrite and dynamic loss scaling).")
 
 
 def set_hparams_from_args(args):

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -143,6 +143,7 @@ flags.DEFINE_integer("log_step_count_steps", 100,
                      "out")
 
 
+
 def set_hparams_from_args(args):
   """Set hparams overrides from unparsed args list."""
   if not args:

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -141,9 +141,6 @@ flags.DEFINE_string("job-dir", None,
 flags.DEFINE_integer("log_step_count_steps", 100,
                      "Number of local steps after which progress is printed "
                      "out")
-flags.DEFINE_bool("gpu_automatic_mixed_precision", False,
-                  "Whether to employ GPU automatic mixed precision training "
-                  "(via graph rewrite and dynamic loss scaling).")
 
 
 def set_hparams_from_args(args):

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -141,7 +141,9 @@ flags.DEFINE_string("job-dir", None,
 flags.DEFINE_integer("log_step_count_steps", 100,
                      "Number of local steps after which progress is printed "
                      "out")
-
+flags.DEFINE_bool("gpu_automatic_mixed_precision", False,
+                  "Whether to employ GPU automatic mixed precision training "
+                  "(via graph rewrite and dynamic loss scaling).")
 
 
 def set_hparams_from_args(args):
@@ -385,6 +387,8 @@ def main(argv):
     set_hparams_from_args(argv[1:])
   if FLAGS.schedule != "run_std_server":
     hparams = create_hparams()
+  if FLAGS.gpu_automatic_mixed_precision:
+    setattr(hparams, "gpu_automatic_mixed_precision", True)
 
   if FLAGS.schedule == "train" or FLAGS.schedule == "train_eval_and_decode":
     mlperf_log.transformer_print(key=mlperf_log.RUN_START, hparams=hparams)

--- a/tensor2tensor/layers/common_hparams.py
+++ b/tensor2tensor/layers/common_hparams.py
@@ -347,7 +347,9 @@ def basic_params1():
       num_area_layers=0,
       max_area_width=1,
       max_area_height=1,
-      memory_height=1
+      memory_height=1,
+      # Whether to use GPU automatic mixed precision (via graph rewrite)
+      gpu_automatic_mixed_precision=False
   )
 
 

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -69,7 +69,7 @@ def optimize(loss,
   opt = ConditionalOptimizer(hparams.optimizer, learning_rate, hparams, use_tpu)
   if use_tpu:
     opt = tf.contrib.tpu.CrossShardOptimizer(opt)
-  if tf.flags.FLAGS.gpu_automatic_mixed_precision:
+  if hparams.gpu_automatic_mixed_precision:
     if use_tpu:
       raise RuntimeError("GPU auto mixed precision cannot be used with TPU")
     elif _mixed_precision_is_enabled(hparams):

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -69,7 +69,7 @@ def optimize(loss,
   opt = ConditionalOptimizer(hparams.optimizer, learning_rate, hparams, use_tpu)
   if use_tpu:
     opt = tf.contrib.tpu.CrossShardOptimizer(opt)
-  if hparams.gpu_automatic_mixed_precision:
+  if getattr(hparams, "gpu_automatic_mixed_precision", False):
     if use_tpu:
       raise RuntimeError("GPU auto mixed precision cannot be used with TPU")
     elif _mixed_precision_is_enabled(hparams):

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -45,8 +45,7 @@ def optimize(loss,
              learning_rate,
              hparams,
              use_tpu=False,
-             variables=None,
-             gpu_auto_mixed_precision=False):
+             variables=None):
   """Minimize loss."""
   loss = weight_decay_and_noise(loss, hparams, learning_rate)
   loss = tf.identity(loss, name="total_loss")
@@ -71,7 +70,7 @@ def optimize(loss,
   opt = ConditionalOptimizer(hparams.optimizer, learning_rate, hparams, use_tpu)
   if use_tpu:
     opt = tf.contrib.tpu.CrossShardOptimizer(opt)
-  if hparams.gpu_automatic_mixed_precision:
+  if tf.flags.FLAGS.gpu_automatic_mixed_precision:
     if use_tpu:
       raise RuntimeError("GPU auto mixed precision cannot be used with TPU")
     elif _mixed_precision_is_enabled(hparams):

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
 import numpy as np
 from tensor2tensor.layers import common_layers
 from tensor2tensor.utils import adafactor as adafactor_lib

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -71,7 +71,7 @@ def optimize(loss,
   opt = ConditionalOptimizer(hparams.optimizer, learning_rate, hparams, use_tpu)
   if use_tpu:
     opt = tf.contrib.tpu.CrossShardOptimizer(opt)
-  if hparams.gpu_auto_mixed_precision:
+  if hparams.gpu_automatic_mixed_precision:
     if use_tpu:
       raise RuntimeError("GPU auto mixed precision cannot be used with TPU")
     elif _mixed_precision_is_enabled(hparams):

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -71,8 +71,7 @@ def optimize(loss,
   opt = ConditionalOptimizer(hparams.optimizer, learning_rate, hparams, use_tpu)
   if use_tpu:
     opt = tf.contrib.tpu.CrossShardOptimizer(opt)
-  if gpu_auto_mixed_precision or os.environ.get(
-      "TF_ENABLE_AUTO_MIXED_PRECISION", "0") == "1":
+  if hparams.gpu_auto_mixed_precision:
     if use_tpu:
       raise RuntimeError("GPU auto mixed precision cannot be used with TPU")
     elif _mixed_precision_is_enabled(hparams):


### PR DESCRIPTION
In continuation of  https://github.com/tensorflow/tensor2tensor/pull/1637 and in response to @afrozenator 's comments in https://github.com/tensorflow/tensor2tensor/pull/1680

In this PR, we re-organize automatic mixed precision training support to provide a cleaner implementation and an easier interface via using hyper parameters. 

In particular, [GPU automatic mixed precision training](https://medium.com/tensorflow/automatic-mixed-precision-in-tensorflow-for-faster-ai-training-on-nvidia-gpus-6033234b2540) can now be enabled via setting a flag (and correspondingly a so-named hyper-parameter) `gpu_automatic_mixed_precision` for **all tensor2tensor models**, for example: 

**Transformer**
```
PROBLEM=translate_ende_wmt32k
MODEL=transformer
HPARAMS=transformer_big
DATA_DIR=/data/translate_ende_wmt32k
TRAIN_DIR=/tmp/$MODEL-$HPARAMS

t2t-trainer \
  --data_dir=$DATA_DIR \
  --problem=$PROBLEM \
  --model=$MODEL \
  --hparams_set=$HPARAMS \
  --output_dir=$TRAIN_DIR \
  --train_steps=100000 \
  --eval_steps=1000 \
  --gpu_automatic_mixed_precision=True
```

**Resnet:**
```
PROBLEM=image_imagenet224
MODEL=resnet
HPARAMS=resnet_50
DATA_DIR=/data/ImageNet
TRAIN_DIR=/tmp/$HPARAMS

t2t-trainer \
  --data_dir=$DATA_DIR \
  --problem=$PROBLEM \
  --model=$MODEL \
  --hparams_set=$HPARAMS \
  --output_dir=$TRAIN_DIR \
  --hparams='batch_size=256' \
  --worker_gpu=8 \
  --gpu_automatic_mixed_precision=True
```

This is opposed to the previous approaches of setting the OS flag `TF_ENABLE_AUTO_MIXED_PRECISION` which is a non-programatic approach, or passing the flag `gpu_auto_mixed_precision` directly to the optimizer (which will require modification of individual models to make call to optimizer with mixed precision training option). 