### PR TITLE
Fix serving response from Cloud ML Engine

### DIFF
--- a/tensor2tensor/serving/serving_utils.py
+++ b/tensor2tensor/serving/serving_utils.py
@@ -23,6 +23,7 @@ import base64
 import functools
 from googleapiclient import discovery
 import grpc
+import numpy as np
 
 from tensor2tensor import problems as problems_lib  # pylint: disable=unused-import
 from tensor2tensor.data_generators import text_encoder
@@ -140,8 +141,12 @@ def make_cloud_mlengine_request_fn(credentials, model_name, version):
             }
         } for ex in examples]
     }
-    prediction = api.projects().predict(body=input_data, name=parent).execute()
-    return prediction["predictions"]
+    response = api.projects().predict(body=input_data, name=parent).execute()
+    predictions = response["predictions"]
+    for prediction in predictions:
+      prediction["outputs"] = np.array([prediction["outputs"]])
+      prediction["scores"] = np.array(prediction["scores"])
+    return predictions
 
   return _make_cloud_mlengine_request
 


### PR DESCRIPTION
## Problem

When we use `t2t-query-server` and `TensorFlow Serving` is hosted by our own(gRPC), the responses are from `TensorFlow Serving` converted to `ndarray`.
https://github.com/tensorflow/tensor2tensor/blob/8a95e96f31d1beccb8efbb2290f6a271600eb3f3/tensor2tensor/serving/serving_utils.py#L116-L123

But when we use it with Cloud ML Engine, the responses are not converted.
https://github.com/tensorflow/tensor2tensor/blob/8a95e96f31d1beccb8efbb2290f6a271600eb3f3/tensor2tensor/serving/serving_utils.py#L143-L144

then, got error,

```bash
Traceback (most recent call last):
  File "//anaconda3/envs/py27/lib/python2.7/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "//anaconda3/envs/py27/lib/python2.7/site-packages/flask/app.py", line 1951, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "//anaconda3/envs/py27/lib/python2.7/site-packages/flask/app.py", line 1820, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "//anaconda3/envs/py27/lib/python2.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "//anaconda3/envs/py27/lib/python2.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/evalphobia/repos/my-t2t-transformer-jp/export/query/src/server.py", line 101, in endpoint
    outputs = serving_utils.predict([inputs], problem, request_fn)
  File "//anaconda3/envs/py27/lib/python2.7/site-packages/tensor2tensor/serving/serving_utils.py", line 165, in predict
    for prediction in predictions
  File "//anaconda3/envs/py27/lib/python2.7/site-packages/tensor2tensor/serving/serving_utils.py", line 97, in _decode
    if len(output_ids.shape) > 1:
AttributeError: 'list' object has no attribute 'shape'
```

## Changes
Just convert them to ndarray.

