### PR TITLE
Fix the decode_length for decoding

### DIFF
--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -453,7 +453,7 @@ def decode_from_file(estimator,
           task_id=decode_hp.multiproblem_task_id, has_input=has_input)
       gen_fn = make_input_fn_from_generator(input_gen)
       example = gen_fn()
-      return _decode_input_tensor_to_features_dict(example, hparams)
+      return _decode_input_tensor_to_features_dict(example, hparams, decode_hp)
   decodes = []
   result_iter = estimator.predict(input_fn, checkpoint_path=checkpoint_path)
 
@@ -937,12 +937,13 @@ def _interactive_input_tensor_to_features_dict(feature_map, hparams):
   return features
 
 
-def _decode_input_tensor_to_features_dict(feature_map, hparams):
+def _decode_input_tensor_to_features_dict(feature_map, hparams, decode_hp):
   """Convert the interactive input format (see above) to a dictionary.
 
   Args:
     feature_map: dict with inputs.
     hparams: model hyperparameters
+    decode_hp: decode hyperparameters
 
   Returns:
     a features dictionary, as expected by the decoder.
@@ -962,7 +963,7 @@ def _decode_input_tensor_to_features_dict(feature_map, hparams):
   features["input_space_id"] = input_space_id
   features["target_space_id"] = target_space_id
   features["decode_length"] = (
-      IMAGE_DECODE_LENGTH if input_is_image else tf.shape(x)[1] + 50)
+      IMAGE_DECODE_LENGTH if input_is_image else tf.constant(decode_hp.extra_length))
   features["inputs"] = x
   # Save inputs to "partial_targets" when prepending inputs to targets. Also
   # keep "inputs" as some models crash if they don't exist.


### PR DESCRIPTION
Originally the decode length is hard-coded in the `decoding.py`. 

I believe that is a bug because the `extra_length` set in `decode_hp` should be used as the `decode_length` rather than the original `tf.shape(x)[1] + 50`, referring to the usage of `features['decode_length']` in the followings:
https://github.com/tensorflow/tensor2tensor/blob/8107e53e8d8896c521522e9335a266b4b7510c37/tensor2tensor/utils/t2t_model.py#L932-L933 https://github.com/tensorflow/tensor2tensor/blob/8107e53e8d8896c521522e9335a266b4b7510c37/tensor2tensor/models/transformer.py#L712-L713