### PR TITLE
inaccurate calculation of first_token's pos_embedding

### DIFF
--- a/tensor2tensor/models/research/glow_ops.py
+++ b/tensor2tensor/models/research/glow_ops.py
@@ -389,12 +389,7 @@ def invertible_1x1_conv(name, x, reverse=False):
       w = tf.reshape(w, [1, 1] + w_shape)
       x = tf.nn.conv2d(x, w, [1, 1, 1, 1], "SAME", data_format="NHWC")
     else:
-      # TODO(b/111271662): Remove when supported.
-      def tpu_inv(m):
-        """tf.linalg.inv workaround until it is supported on TPU."""
-        q, r = tf.linalg.qr(m)
-        return tf.linalg.triangular_solve(r, tf.transpose(q), lower=False)
-      w_inv = tf.reshape(tpu_inv(w), [1, 1]+w_shape)
+      w_inv = tf.reshape(tf.linalg.inv(w), [1, 1]+w_shape)
       x = tf.nn.conv2d(
           x, w_inv, [1, 1, 1, 1], "SAME", data_format="NHWC")
       objective *= -1


### PR DESCRIPTION
since,
1. scaled_time is calculated by `scaled_time = tf.expand_dims(position, 1) * tf.expand_dims(inv_timescales, 0)`, while position_idx in position will **start by 0**.
2. scaled_time will be used to calculate position embedding by `signal = tf.concat([tf.sin(scaled_time), tf.cos(scaled_time)], axis=1)`

Thus, position_embedding of first token will always be combined with half zeros and half ones.

But the purpose of addding timing pos_embed should be helping model to learn relative and absolute position information between words by triangle relations of these words, i.e. sin(\alpha+\beta)=sin(\alpha)cos(\beta)+sin(\beta)cos(\alpha).