### PR TITLE
Fixed a mistake in a doc comment

### DIFF
--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -783,7 +783,7 @@ class T2TModel(base.Layer):
     Returns:
       A dict of decoding results {
           "outputs": integer `Tensor` of decoded ids of shape
-              [batch_size, <= decode_length] if beam_size == 1 or
+              [batch_size, <= decode_length] if top_beams == 1 or
               [batch_size, top_beams, <= decode_length]
           "scores": decoding log probs from the beam search,
               None if using greedy decoding (beam_size=1)


### PR DESCRIPTION
In T2TModel.infer, the comment mentioned that the returned outputs tensor has a shape of `[batch_size, <= decode_length] if beam_size == 1`, but this is wrong. It should be: `if top_beams == 1`. It is a simple mistake but it may really confuse a beginner (like me).