### PR TITLE
Neural Shuffle-Exchange Seq2Seq model

### DIFF
--- a/tensor2tensor/models/__init__.py
+++ b/tensor2tensor/models/__init__.py
@@ -73,6 +73,7 @@ from tensor2tensor.models.research import universal_transformer
 from tensor2tensor.models.research import vqa_attention
 from tensor2tensor.models.research import vqa_recurrent_self_attention
 from tensor2tensor.models.research import vqa_self_attention
+from tensor2tensor.models.research import shuffle_network
 
 from tensor2tensor.models.video import basic_deterministic
 from tensor2tensor.models.video import basic_recurrent

--- a/tensor2tensor/models/__init__.py
+++ b/tensor2tensor/models/__init__.py
@@ -20,8 +20,6 @@ from __future__ import print_function
 
 import six
 
-# pylint: disable=unused-import
-
 from tensor2tensor.layers import modalities  # pylint: disable=g-import-not-at-top
 from tensor2tensor.models import basic
 from tensor2tensor.models import bytenet
@@ -44,9 +42,7 @@ from tensor2tensor.models import text_cnn
 from tensor2tensor.models import transformer
 from tensor2tensor.models import vanilla_gan
 from tensor2tensor.models import xception
-
 from tensor2tensor.models.neural_architecture_search import nas_model
-
 from tensor2tensor.models.research import adafactor_experiments
 from tensor2tensor.models.research import aligned
 from tensor2tensor.models.research import attention_lm
@@ -60,6 +56,7 @@ from tensor2tensor.models.research import moe_experiments
 from tensor2tensor.models.research import multiquery_paper
 from tensor2tensor.models.research import neural_stack
 from tensor2tensor.models.research import rl
+from tensor2tensor.models.research import shuffle_network
 from tensor2tensor.models.research import similarity_transformer
 from tensor2tensor.models.research import super_lm
 from tensor2tensor.models.research import transformer_moe
@@ -73,8 +70,6 @@ from tensor2tensor.models.research import universal_transformer
 from tensor2tensor.models.research import vqa_attention
 from tensor2tensor.models.research import vqa_recurrent_self_attention
 from tensor2tensor.models.research import vqa_self_attention
-from tensor2tensor.models.research import shuffle_network
-
 from tensor2tensor.models.video import basic_deterministic
 from tensor2tensor.models.video import basic_recurrent
 from tensor2tensor.models.video import basic_stochastic
@@ -83,8 +78,10 @@ from tensor2tensor.models.video import epva
 from tensor2tensor.models.video import next_frame_glow
 from tensor2tensor.models.video import savp
 from tensor2tensor.models.video import sv2p
-
 from tensor2tensor.utils import registry
+
+
+# pylint: disable=unused-import
 
 # pylint: enable=unused-import
 

--- a/tensor2tensor/models/research/shuffle_network.py
+++ b/tensor2tensor/models/research/shuffle_network.py
@@ -1,25 +1,26 @@
-"""
+"""Neural Shuffle-Exchange Network.
+
 Implementation of
 "Neural Shuffle-Exchange Networks - Sequence Processing in O(n log n) Time"
 paper by K.Freivalds, E.Ozolins, A.Sostaks.
+
 Paper: https://papers.nips.cc/paper/
 8889-neural-shuffle-exchange-networks-sequence-processing-in-on-log-n-time.pdf
+
 Original code: https://github.com/LUMII-Syslab/shuffle-exchange
 """
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
-
 from tensor2tensor.layers import common_hparams
 from tensor2tensor.utils import registry
 from tensor2tensor.utils import t2t_model
+import tensorflow as tf
 
 
 def ror(x, n, p=1):
-  """
-  Bitwise right rotation.
+  """Bitwise right rotation.
 
   Args:
     x: Input tensor
@@ -39,8 +40,7 @@ def ror(x, n, p=1):
 
 
 def rol(x, n, p=1):
-  """
-  Bitwise left rotation.
+  """Bitwise left rotation.
 
   Args:
     x: Input tensor
@@ -59,9 +59,7 @@ def rol(x, n, p=1):
 
 
 def shuffle_layer(inputs, shuffle_fn=rol):
-  """
-  Shuffles the elements according to bitwise left or right rotation
-  on their indices.
+  """Shuffles the elements according to bitwise left or right rotation.
 
   Args:
     inputs: Tensor input from previous layer
@@ -81,8 +79,7 @@ def shuffle_layer(inputs, shuffle_fn=rol):
 
 
 def reverse_shuffle_layer(inputs):
-  """
-  Reverse shuffle of inputs. Used in the second half of Benes block.
+  """Reverse shuffle of inputs. Used in the second half of Benes block.
 
   Args:
     inputs: Inputs that should be shuffled
@@ -95,8 +92,7 @@ def reverse_shuffle_layer(inputs):
 
 
 def conv_linear_map(inputs, nin, nout, bias_start, prefix):
-  """
-  Convolutional liner map. Maps 3D tensor by last dimension.
+  """Convolutional liner map. Maps 3D tensor by last dimension.
 
   Args:
     inputs: Inputs that should be shuffled
@@ -127,13 +123,12 @@ def conv_linear_map(inputs, nin, nout, bias_start, prefix):
 
 # pylint: disable=useless-object-inheritance
 class SwitchLayer(object):
-  """
-  Switch layer of Neural Shuffle-Exchange network.
-  Neural adaption of switch unit in standart Benes networks.
+  """Switch layer of Neural Shuffle-Exchange network.
   """
 
   def __init__(self, prefix, dropout, mode):
-    """
+    """Initialize switch layer.
+
     Args:
       prefix: Name prefix for switch layer
       dropout: Dropout rate
@@ -149,7 +144,7 @@ class SwitchLayer(object):
     self.n_bits = None
 
   def linear_map(self, inputs, suffix, bias_start, in_units, out_units):
-    """2 input to 2 output linear map
+    """2 input to 2 output linear map.
 
     Args:
       inputs: Input tensor
@@ -169,8 +164,7 @@ class SwitchLayer(object):
 
   def gated_linear_map(self, inputs, suffix, bias_start_reset,
                        in_units, out_units):
-    """
-    Linear mapping with two reset gates
+    """Linear mapping with two reset gates.
 
     Args:
       inputs: Input tensor
@@ -204,8 +198,7 @@ class SwitchLayer(object):
     return tf.nn.tanh(res)
 
   def __call__(self, inputs, residual_inputs):
-    """
-    Apply SwitchLayer to inputs:
+    """Apply SwitchLayer to inputs.
 
     Args:
       inputs: Input tensor
@@ -246,8 +239,7 @@ class SwitchLayer(object):
     return candidate
 
   def swap_halves(self, inputs):
-    """
-    Split inputs in half and then shuffle them as described in paper.
+    """Split inputs in half and then shuffle them as described in paper.
 
     Args:
       inputs: ShuffleLayer inputs
@@ -263,9 +255,7 @@ class SwitchLayer(object):
 
 
 def shuffle_network(inputs, hparams):
-  """
-  Neural Shuffle-Network with skip connections between blocks.
-  Adaption of Benes network.
+  """Neural Shuffle-Network with skip connections between blocks.
 
   Args:
     inputs: inputs to the Shuffle-Exchange network.
@@ -331,8 +321,7 @@ class ShuffleNetwork(t2t_model.T2TModel):
   """
 
   def bottom(self, features):
-    """
-    We add padding to the input and output so they are the same.
+    """We add padding to the input and output so they are the same.
     Length of input and output should be power of 2.
 
     Args:
@@ -359,15 +348,16 @@ class ShuffleNetwork(t2t_model.T2TModel):
     return super(ShuffleNetwork, self).bottom(features)
 
   def loss(self, logits, features):
-    """
+    """Loss function for Neural Shuffle-Exchange network.
+
     We use custom loss function as default loss function doesn't
-    use padding for calculating loss.
-    We assume that output string is same length as the input. If you need other
-    type of output please feel free to modify this.
+    use padding for calculating loss. We assume that output string is same
+    length as the input. If you need other type of output please feel
+    free to modify this.
 
     Args:
       logits: Logits from model
-      features: Features, not in onehot_format
+      features: Features, not in one-hot format
 
     Returns:
        tf.Tensor: Loss value
@@ -376,13 +366,12 @@ class ShuffleNetwork(t2t_model.T2TModel):
     onehot_labels = tf.one_hot(features["targets"],
                                self._problem_hparams.vocab_size["targets"])
     cost_vector = tf.nn.softmax_cross_entropy_with_logits_v2(
-        logits=logits,
-        labels=onehot_labels)
+      logits=logits,
+      labels=onehot_labels)
     return tf.reduce_mean(cost_vector)
 
   def body(self, features):
-    """
-    Body of Neural Shuffle-Exchange network.
+    """Body of Neural Shuffle-Exchange network.
 
     Args:
       features: dictionary of inputs and targets
@@ -396,6 +385,9 @@ class ShuffleNetwork(t2t_model.T2TModel):
 @registry.register_hparams
 def shuffle_network_baseline():
   """Large Shuffle-Exchange configuration.
+
+  Returns:
+    dict: Neural Shuffle-Exchange configuration
   """
 
   hparams = common_hparams.basic_params1()

--- a/tensor2tensor/models/research/shuffle_network.py
+++ b/tensor2tensor/models/research/shuffle_network.py
@@ -1,5 +1,5 @@
 """
-Implementation of "Neural Shuffle-Exchange Networks − Sequence Processing in O(n log n) Time" paper
+Implementation of "Neural Shuffle-Exchange Networks - Sequence Processing in O(n log n) Time" paper
 by K.Freivalds, E.Ozolins, A.Sostaks.
 Paper: https://papers.nips.cc/paper/8889-neural-shuffle-exchange-networks-sequence-processing-in-on-log-n-time.pdf
 Original code: https://github.com/LUMII-Syslab/shuffle-exchange
@@ -65,7 +65,7 @@ def conv_linear_map(inputs, nin, nout, bias_start, prefix):
 
 class SwitchLayer:
 
-  def __init__(self, prefix, dropout, mode) -> None:
+  def __init__(self, prefix, dropout, mode):
     self.prefix = prefix
     self.dropout = dropout
     self.mode = mode
@@ -115,7 +115,7 @@ class SwitchLayer:
     initializer = tf.constant_initializer(0.5)
     residual_scale = tf.get_variable(self.prefix + "/residual_scale", [self.num_units], initializer=initializer)
 
-    shuffled_input = self.shuffle_inputs(inputs)
+    shuffled_input = self.swap_halves(inputs)
     mem_all = inputs + residual_inputs * residual_scale
 
     # calculate the new value
@@ -208,7 +208,7 @@ class ShuffleNetwork(t2t_model.T2TModel):
 
     features["inputs"] = tf.pad(inputs, [[0, 0], [0, pad_len - inputs_length], [0, 0], [0, 0]])
     features["targets"] = tf.pad(targets, [[0, 0], [0, pad_len - targets_length], [0, 0], [0, 0]])
-    return super().bottom(features)
+    return super(ShuffleNetwork, self).bottom(features)
 
   def loss(self, logits, features):
     """

--- a/tensor2tensor/models/research/shuffle_network.py
+++ b/tensor2tensor/models/research/shuffle_network.py
@@ -1,3 +1,9 @@
+"""
+Implementation of "Neural Shuffle-Exchange Networks − Sequence Processing in O(n log n) Time" paper
+by K.Freivalds, E.Ozolins, A.Sostaks.
+Paper: https://papers.nips.cc/paper/8889-neural-shuffle-exchange-networks-sequence-processing-in-on-log-n-time.pdf
+Original code: https://github.com/LUMII-Syslab/shuffle-exchange
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -10,233 +16,237 @@ from tensor2tensor.utils import t2t_model
 
 
 def ror(x, n, p=1):
-    """Bitwise rotation right"""
-    a = tf.bitwise.right_shift(x, p)
-    b = tf.bitwise.left_shift(1, p) - 1
-    c = tf.bitwise.bitwise_and(x, b)
-    d = tf.bitwise.left_shift(c, n - p)
+  """Bitwise right rotation """
+  a = tf.bitwise.right_shift(x, p)
+  b = tf.bitwise.left_shift(1, p) - 1
+  c = tf.bitwise.bitwise_and(x, b)
+  d = tf.bitwise.left_shift(c, n - p)
 
-    return a + d
+  return a + d
 
 
 def rol(x, n, p=1):
-    """Bitwise rotation left"""
-    a = tf.bitwise.left_shift(x, p)
-    b = tf.bitwise.left_shift(1, n) - 1
-    c = tf.bitwise.bitwise_and(a, b)
-    d = tf.bitwise.right_shift(x, n - p)
-    return tf.bitwise.bitwise_or(c, d)
+  """Bitwise left rotation"""
+  a = tf.bitwise.left_shift(x, p)
+  b = tf.bitwise.left_shift(1, n) - 1
+  c = tf.bitwise.bitwise_and(a, b)
+  d = tf.bitwise.right_shift(x, n - p)
+
+  return tf.bitwise.bitwise_or(c, d)
 
 
 def shuffle_layer(inputs, shuffle_fn=rol):
-    """Shuffles the elements according to bitwise left or right rotation on their indices"""
-    length = tf.shape(inputs)[1]
-    n_bits = tf.log(tf.cast(length - 1, tf.float32)) / tf.log(2.0)
-    n_bits = tf.cast(n_bits, tf.int32) + 1
+  """Shuffles the elements according to bitwise left or right rotation on their indices"""
+  length = tf.shape(inputs)[1]
+  n_bits = tf.log(tf.cast(length - 1, tf.float32)) / tf.log(2.0)
+  n_bits = tf.cast(n_bits, tf.int32) + 1
 
-    indices = tf.range(0, length)
-    rev_indices = shuffle_fn(indices, n_bits)
-    return tf.gather(inputs, rev_indices, axis=1)
+  indices = tf.range(0, length)
+  rev_indices = shuffle_fn(indices, n_bits)
+  return tf.gather(inputs, rev_indices, axis=1)
 
 
 def reverse_shuffle_layer(inputs):
-    return shuffle_layer(inputs, ror)
+  return shuffle_layer(inputs, ror)
 
 
 def conv_linear_map(inputs, nin, nout, bias_start, prefix):
-    with tf.variable_scope(prefix):
-        inp_shape = tf.shape(inputs)
+  with tf.variable_scope(prefix):
+    inp_shape = tf.shape(inputs)
 
-        initializer = tf.variance_scaling_initializer(scale=1.0, mode="fan_avg", distribution="uniform")
-        kernel = tf.get_variable("CvK", [nin, nout], initializer=initializer)
-        bias_term = tf.get_variable("CvB", [nout], initializer=tf.constant_initializer(0.0))
+    initializer = tf.variance_scaling_initializer(scale=1.0, mode="fan_avg", distribution="uniform")
+    kernel = tf.get_variable("CvK", [nin, nout], initializer=initializer)
+    bias_term = tf.get_variable("CvB", [nout], initializer=tf.constant_initializer(0.0))
 
-        res = tf.matmul(tf.reshape(inputs, [inp_shape[0] * inp_shape[1], nin]), kernel)
-        res = tf.reshape(res, [inp_shape[0], inp_shape[1], nout])
-        return res + bias_start + bias_term
+    res = tf.matmul(tf.reshape(inputs, [inp_shape[0] * inp_shape[1], nin]), kernel)
+    res = tf.reshape(res, [inp_shape[0], inp_shape[1], nout])
+    return res + bias_start + bias_term
 
 
 class SwitchLayer:
 
-    def __init__(self, prefix, dropout, mode) -> None:
-        self.prefix = prefix
-        self.dropout = dropout
-        self.mode = mode
-        self.batch_size = None
-        self.length = None
-        self.num_units = None
-        self.n_bits = None
+  def __init__(self, prefix, dropout, mode) -> None:
+    self.prefix = prefix
+    self.dropout = dropout
+    self.mode = mode
+    self.batch_size = None
+    self.length = None
+    self.num_units = None
+    self.n_bits = None
 
-    def linear_map(self, inputs, suffix, bias_start, in_units, out_units):
-        """
-        2 input to 2 output linear map
-        """
-        inputs = tf.reshape(inputs, [self.batch_size, self.length // 2, in_units * 2])
-        res = conv_linear_map(inputs, in_units * 2, out_units * 2, bias_start, self.prefix + "/" + suffix)
-        return tf.reshape(res, [self.batch_size, self.length, out_units])
+  def linear_map(self, inputs, suffix, bias_start, in_units, out_units):
+    """
+    2 input to 2 output linear map
+    """
+    inputs = tf.reshape(inputs, [self.batch_size, self.length // 2, in_units * 2])
+    res = conv_linear_map(inputs, in_units * 2, out_units * 2, bias_start, self.prefix + "/" + suffix)
+    return tf.reshape(res, [self.batch_size, self.length, out_units])
 
-    def gated_linear_map(self, inputs, suffix, bias_start_reset, in_units, out_units):
-        """
-        Linear mapping with two reset gates
-        """
+  def gated_linear_map(self, inputs, suffix, bias_start_reset, in_units, out_units):
+    """
+    Linear mapping with two reset gates
+    """
 
-        def reset_gate(name):
-            prefix = self.prefix + name + suffix
-            reset = conv_linear_map(inputs, in_units * 2, in_units * 2, bias_start_reset, prefix)
-            return tf.nn.sigmoid(reset)
+    def reset_gate(name):
+      prefix = self.prefix + name + suffix
+      reset = conv_linear_map(inputs, in_units * 2, in_units * 2, bias_start_reset, prefix)
+      return tf.nn.sigmoid(reset)
 
-        inputs = tf.reshape(inputs, [self.batch_size, self.length // 2, in_units * 2])
+    inputs = tf.reshape(inputs, [self.batch_size, self.length // 2, in_units * 2])
 
-        reset1 = reset_gate("/reset1/")
-        reset2 = reset_gate("/reset2/")
-        res1 = conv_linear_map(inputs * reset1, in_units * 2, out_units, 0.0, self.prefix + "/cand1/" + suffix)
-        res2 = conv_linear_map(inputs * reset2, in_units * 2, out_units, 0.0, self.prefix + "/cand2/" + suffix)
+    reset1 = reset_gate("/reset1/")
+    reset2 = reset_gate("/reset2/")
+    res1 = conv_linear_map(inputs * reset1, in_units * 2, out_units, 0.0, self.prefix + "/cand1/" + suffix)
+    res2 = conv_linear_map(inputs * reset2, in_units * 2, out_units, 0.0, self.prefix + "/cand2/" + suffix)
 
-        res = tf.concat([res1, res2], axis=2)
-        res = tf.reshape(res, [self.batch_size, self.length, out_units])
-        return tf.nn.tanh(res)
+    res = tf.concat([res1, res2], axis=2)
+    res = tf.reshape(res, [self.batch_size, self.length, out_units])
+    return tf.nn.tanh(res)
 
-    def __call__(self, inputs, residual_inputs):
-        input_shape = tf.shape(inputs)
-        self.batch_size = input_shape[0]
-        self.length = input_shape[1]
-        self.num_units = inputs.shape.as_list()[2]
+  def __call__(self, inputs, residual_inputs):
+    input_shape = tf.shape(inputs)
+    self.batch_size = input_shape[0]
+    self.length = input_shape[1]
+    self.num_units = inputs.shape.as_list()[2]
 
-        self.n_bits = tf.log(tf.cast(self.length - 1, tf.float32)) / tf.log(2.0)
-        self.n_bits = tf.floor(self.n_bits) + 1
+    self.n_bits = tf.log(tf.cast(self.length - 1, tf.float32)) / tf.log(2.0)
+    self.n_bits = tf.floor(self.n_bits) + 1
 
-        initializer = tf.constant_initializer(0.5)
-        residual_scale = tf.get_variable(self.prefix + "/residual_scale", [self.num_units], initializer=initializer)
+    initializer = tf.constant_initializer(0.5)
+    residual_scale = tf.get_variable(self.prefix + "/residual_scale", [self.num_units], initializer=initializer)
 
-        shuffled_input = self.shuffle_inputs(inputs)
-        mem_all = inputs + residual_inputs * residual_scale
+    shuffled_input = self.shuffle_inputs(inputs)
+    mem_all = inputs + residual_inputs * residual_scale
 
-        # calculate the new value
-        candidate = self.gated_linear_map(mem_all, "c", 0.5, self.num_units, self.num_units)
-        gate = tf.nn.sigmoid(self.linear_map(mem_all, "g", 0.5, self.num_units, self.num_units))
+    # calculate the new value
+    candidate = self.gated_linear_map(mem_all, "c", 0.5, self.num_units, self.num_units)
+    gate = tf.nn.sigmoid(self.linear_map(mem_all, "g", 0.5, self.num_units, self.num_units))
 
-        candidate = gate * shuffled_input + (1 - gate) * candidate
+    candidate = gate * shuffled_input + (1 - gate) * candidate
 
-        if self.dropout > 0:
-            candidate = tf.nn.dropout(candidate, rate=self.dropout / self.n_bits)
-        if not self.dropout == 0.0 and self.mode == tf.estimator.ModeKeys.TRAIN:
-            candidate = candidate * tf.random_normal(tf.shape(candidate), mean=1.0, stddev=0.001)
+    if self.dropout > 0:
+      candidate = tf.nn.dropout(candidate, rate=self.dropout / self.n_bits)
+    if not self.dropout == 0.0 and self.mode == tf.estimator.ModeKeys.TRAIN:
+      candidate = candidate * tf.random_normal(tf.shape(candidate), mean=1.0, stddev=0.001)
 
-        return candidate
+    return candidate
 
-    def shuffle_inputs(self, inputs):
-        x = tf.range(0, self.length)
-        xor_indices = tf.bitwise.bitwise_xor(x, 1)
-        input_xor = tf.gather(inputs[:, :, :self.num_units // 2], xor_indices, axis=1)
-        return tf.concat([input_xor, inputs[:, :, self.num_units // 2:]], axis=2)
+  def swap_halves(self, inputs):
+    x = tf.range(0, self.length)
+    xor_indices = tf.bitwise.bitwise_xor(x, 1)
+    input_xor = tf.gather(inputs[:, :, :self.num_units // 2], xor_indices, axis=1)
+    return tf.concat([input_xor, inputs[:, :, self.num_units // 2:]], axis=2)
 
 
 def shuffle_network(inputs, hparams):
-    """Neural Benes Network with skip connections between blocks."""
+  """Neural Benes Network with skip connections between blocks."""
 
-    def forward_step(state, layer_nr):
-        with tf.variable_scope("forward"):
-            last_state, residuals = state
-            prev = residuals[layer_nr, :, :, :]
-            cur = SwitchLayer("switch", hparams.dropout, hparams.mode)(last_state, prev)
-            return shuffle_layer(cur), residuals
+  def forward_step(state, layer_nr):
+    with tf.variable_scope("forward"):
+      last_state, residuals = state
+      prev = residuals[layer_nr, :, :, :]
+      cur = SwitchLayer("switch", hparams.dropout, hparams.mode)(last_state, prev)
+      return shuffle_layer(cur), residuals
 
-    def reverse_step(state, layer_nr):
-        with tf.variable_scope("reverse"):
-            last_state, residuals = state
-            prev = residuals[layer_nr, :, :, :]
-            cur = SwitchLayer("reverse_switch", hparams.dropout, hparams.mode)(last_state, prev)
-            return reverse_shuffle_layer(cur), residuals
+  def reverse_step(state, layer_nr):
+    with tf.variable_scope("reverse"):
+      last_state, residuals = state
+      prev = residuals[layer_nr, :, :, :]
+      cur = SwitchLayer("reverse_switch", hparams.dropout, hparams.mode)(last_state, prev)
+      return reverse_shuffle_layer(cur), residuals
 
-    input_shape = tf.shape(inputs)
-    n_bits = tf.log(tf.cast(input_shape[1] - 1, tf.float32)) / tf.log(2.0)
-    n_bits = tf.cast(n_bits, tf.int32) + 1
+  input_shape = tf.shape(inputs)
+  n_bits = tf.log(tf.cast(input_shape[1] - 1, tf.float32)) / tf.log(2.0)
+  n_bits = tf.cast(n_bits, tf.int32) + 1
 
-    residuals_queue = tf.zeros([n_bits * 2, input_shape[0], input_shape[1], input_shape[2]])
-    block_out = tf.tanh(inputs)
+  residuals_queue = tf.zeros([n_bits * 2, input_shape[0], input_shape[1], input_shape[2]])
+  block_out = tf.tanh(inputs)
 
-    for k in range(hparams.num_hidden_layers):
-        with tf.variable_scope("benes_block_" + str(k), reuse=tf.AUTO_REUSE):
-            forward_outputs, _ = tf.scan(
-                forward_step,
-                tf.range(0, n_bits),
-                initializer=(block_out, residuals_queue),
-                parallel_iterations=1,
-                swap_memory=True
-            )
+  for k in range(hparams.num_hidden_layers):
+    with tf.variable_scope("benes_block_" + str(k), reuse=tf.AUTO_REUSE):
+      forward_outputs, _ = tf.scan(
+        forward_step,
+        tf.range(0, n_bits),
+        initializer=(block_out, residuals_queue),
+        parallel_iterations=1,
+        swap_memory=True
+      )
 
-            forward_outputs = tf.concat([tf.expand_dims(block_out, axis=0), forward_outputs], axis=0)
-            forward_last = forward_outputs[-1, :, :, :]
+      forward_outputs = tf.concat([tf.expand_dims(block_out, axis=0), forward_outputs], axis=0)
+      forward_last = forward_outputs[-1, :, :, :]
 
-            reverse_outputs, _ = tf.scan(
-                reverse_step,
-                tf.range(n_bits, n_bits * 2),
-                initializer=(forward_last, residuals_queue),
-                parallel_iterations=1,
-                swap_memory=True
-            )
+      reverse_outputs, _ = tf.scan(
+        reverse_step,
+        tf.range(n_bits, n_bits * 2),
+        initializer=(forward_last, residuals_queue),
+        parallel_iterations=1,
+        swap_memory=True
+      )
 
-            block_out = reverse_outputs[-1, :, :, :]
-            residuals_queue = tf.concat([forward_outputs, reverse_outputs], axis=0)
+      block_out = reverse_outputs[-1, :, :, :]
+      residuals_queue = tf.concat([forward_outputs, reverse_outputs], axis=0)
 
-    return SwitchLayer("last_layer", hparams.dropout, hparams.mode)(block_out, residuals_queue[n_bits * 2, :, :, :])
+  return SwitchLayer("last_layer", hparams.dropout, hparams.mode)(block_out, residuals_queue[n_bits * 2, :, :, :])
 
 
 @registry.register_model
 class ShuffleNetwork(t2t_model.T2TModel):
+  def bottom(self, features):
     """
-    Implementation of "Neural Shuffle-Exchange Networks − Sequence Processing in O(n log n) Time" paper
-    by K.Freivalds, E.Ozolins, A.Sostaks.
-    Paper: https://papers.nips.cc/paper/8889-neural-shuffle-exchange-networks-sequence-processing-in-on-log-n-time.pdf
+    We add padding to the input and output so they are the same.
+    Length of input and output should be power of 2.
     """
+    inputs = features["inputs"]
+    targets = features["targets"]
+    inputs_length = tf.shape(inputs)[1]
+    targets_length = tf.shape(targets)[1]
 
-    def bottom(self, features):
-        inputs = features["inputs"]
-        targets = features["targets"]
-        inputs_length = tf.shape(inputs)[1]
-        targets_length = tf.shape(targets)[1]
+    length = tf.maximum(inputs_length, targets_length)
+    p = tf.log(tf.cast(length, tf.float32)) / tf.log(2.0)
+    p = tf.cast(tf.ceil(p), tf.int32)
+    pad_len = tf.pow(2, p)
 
-        length = tf.maximum(inputs_length, targets_length)
-        p = tf.log(tf.cast(length, tf.float32)) / tf.log(2.0)
-        p = tf.cast(tf.ceil(p), tf.int32)
-        pad_len = tf.pow(2, p)
+    features["inputs"] = tf.pad(inputs, [[0, 0], [0, pad_len - inputs_length], [0, 0], [0, 0]])
+    features["targets"] = tf.pad(targets, [[0, 0], [0, pad_len - targets_length], [0, 0], [0, 0]])
+    return super().bottom(features)
 
-        features["inputs"] = tf.pad(inputs, [[0, 0], [0, pad_len - inputs_length], [0, 0], [0, 0]])
-        features["targets"] = tf.pad(targets, [[0, 0], [0, pad_len - targets_length], [0, 0], [0, 0]])
-        return super().bottom(features)
+  def loss(self, logits, features):
+    """
+    We use custom loss function as default loss function doesn't
+    use padding for calculating loss.
+    We assume that output string is same length as the input. If you need other
+    type of output please feel free to modify this.
+    """
+    onehot_labels = tf.one_hot(features["targets"], self._problem_hparams.vocab_size["targets"])
+    cost_vector = tf.nn.softmax_cross_entropy_with_logits_v2(logits=logits, labels=onehot_labels)
+    return tf.reduce_mean(cost_vector)
 
-    def loss(self, logits, features):
-        onehot_labels = tf.one_hot(features["targets"], self._problem_hparams.vocab_size["targets"])
-        cost_vector = tf.nn.softmax_cross_entropy_with_logits_v2(logits=logits, labels=onehot_labels)
-        return tf.reduce_mean(cost_vector)
-
-    def body(self, features):
-        inputs = tf.squeeze(features["inputs"], axis=2)
-        logits = shuffle_network(inputs, self._hparams)
-        return tf.expand_dims(logits, axis=2)
+  def body(self, features):
+    inputs = tf.squeeze(features["inputs"], axis=2)
+    logits = shuffle_network(inputs, self._hparams)
+    return tf.expand_dims(logits, axis=2)
 
 
 @registry.register_hparams
 def shuffle_network_baseline():
-    """Set of hyperparameters."""
-    hparams = common_hparams.basic_params1()
-    hparams.hidden_size = 48 * 4  # feature maps
-    hparams.num_hidden_layers = 1  # block count
+  hparams = common_hparams.basic_params1()
+  hparams.hidden_size = 48 * 8  # feature maps
+  hparams.num_hidden_layers = 2  # block count
 
-    hparams.clip_grad_norm = 0.  # no gradient clipping
+  hparams.clip_grad_norm = 0.  # no gradient clipping
 
-    hparams.optimizer = "adam"
-    hparams.optimizer_adam_epsilon = 1e-5
-    hparams.learning_rate_schedule = "legacy"
-    hparams.learning_rate_decay_scheme = "noam"
-    hparams.learning_rate = 0.1
-    hparams.initializer_gain = 1.0
-    hparams.initializer = "uniform_unit_scaling"
-    hparams.optimizer_adam_beta1 = 0.9
-    hparams.optimizer_adam_beta2 = 0.999
+  hparams.optimizer = "adam"
+  hparams.optimizer_adam_epsilon = 1e-5
+  hparams.learning_rate_schedule = "legacy"
+  hparams.learning_rate_decay_scheme = "noam"
+  hparams.learning_rate = 0.1
+  hparams.initializer_gain = 1.0
+  hparams.initializer = "uniform_unit_scaling"
+  hparams.optimizer_adam_beta1 = 0.9
+  hparams.optimizer_adam_beta2 = 0.999
 
-    hparams.dropout = 0.1
-    hparams.label_smoothing = 0.
-    hparams.weight_decay = 0.
+  hparams.dropout = 0.1
+  hparams.label_smoothing = 0.
+  hparams.weight_decay = 0.
 
-    return hparams
+  return hparams

--- a/tensor2tensor/models/research/shuffle_network.py
+++ b/tensor2tensor/models/research/shuffle_network.py
@@ -1,0 +1,242 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from tensor2tensor.layers import common_hparams
+from tensor2tensor.utils import registry
+from tensor2tensor.utils import t2t_model
+
+
+def ror(x, n, p=1):
+    """Bitwise rotation right"""
+    a = tf.bitwise.right_shift(x, p)
+    b = tf.bitwise.left_shift(1, p) - 1
+    c = tf.bitwise.bitwise_and(x, b)
+    d = tf.bitwise.left_shift(c, n - p)
+
+    return a + d
+
+
+def rol(x, n, p=1):
+    """Bitwise rotation left"""
+    a = tf.bitwise.left_shift(x, p)
+    b = tf.bitwise.left_shift(1, n) - 1
+    c = tf.bitwise.bitwise_and(a, b)
+    d = tf.bitwise.right_shift(x, n - p)
+    return tf.bitwise.bitwise_or(c, d)
+
+
+def shuffle_layer(inputs, shuffle_fn=rol):
+    """Shuffles the elements according to bitwise left or right rotation on their indices"""
+    length = tf.shape(inputs)[1]
+    n_bits = tf.log(tf.cast(length - 1, tf.float32)) / tf.log(2.0)
+    n_bits = tf.cast(n_bits, tf.int32) + 1
+
+    indices = tf.range(0, length)
+    rev_indices = shuffle_fn(indices, n_bits)
+    return tf.gather(inputs, rev_indices, axis=1)
+
+
+def reverse_shuffle_layer(inputs):
+    return shuffle_layer(inputs, ror)
+
+
+def conv_linear_map(inputs, nin, nout, bias_start, prefix):
+    with tf.variable_scope(prefix):
+        inp_shape = tf.shape(inputs)
+
+        initializer = tf.variance_scaling_initializer(scale=1.0, mode="fan_avg", distribution="uniform")
+        kernel = tf.get_variable("CvK", [nin, nout], initializer=initializer)
+        bias_term = tf.get_variable("CvB", [nout], initializer=tf.constant_initializer(0.0))
+
+        res = tf.matmul(tf.reshape(inputs, [inp_shape[0] * inp_shape[1], nin]), kernel)
+        res = tf.reshape(res, [inp_shape[0], inp_shape[1], nout])
+        return res + bias_start + bias_term
+
+
+class SwitchLayer:
+
+    def __init__(self, prefix, dropout, mode) -> None:
+        self.prefix = prefix
+        self.dropout = dropout
+        self.mode = mode
+        self.batch_size = None
+        self.length = None
+        self.num_units = None
+        self.n_bits = None
+
+    def linear_map(self, inputs, suffix, bias_start, in_units, out_units):
+        """
+        2 input to 2 output linear map
+        """
+        inputs = tf.reshape(inputs, [self.batch_size, self.length // 2, in_units * 2])
+        res = conv_linear_map(inputs, in_units * 2, out_units * 2, bias_start, self.prefix + "/" + suffix)
+        return tf.reshape(res, [self.batch_size, self.length, out_units])
+
+    def gated_linear_map(self, inputs, suffix, bias_start_reset, in_units, out_units):
+        """
+        Linear mapping with two reset gates
+        """
+
+        def reset_gate(name):
+            prefix = self.prefix + name + suffix
+            reset = conv_linear_map(inputs, in_units * 2, in_units * 2, bias_start_reset, prefix)
+            return tf.nn.sigmoid(reset)
+
+        inputs = tf.reshape(inputs, [self.batch_size, self.length // 2, in_units * 2])
+
+        reset1 = reset_gate("/reset1/")
+        reset2 = reset_gate("/reset2/")
+        res1 = conv_linear_map(inputs * reset1, in_units * 2, out_units, 0.0, self.prefix + "/cand1/" + suffix)
+        res2 = conv_linear_map(inputs * reset2, in_units * 2, out_units, 0.0, self.prefix + "/cand2/" + suffix)
+
+        res = tf.concat([res1, res2], axis=2)
+        res = tf.reshape(res, [self.batch_size, self.length, out_units])
+        return tf.nn.tanh(res)
+
+    def __call__(self, inputs, residual_inputs):
+        input_shape = tf.shape(inputs)
+        self.batch_size = input_shape[0]
+        self.length = input_shape[1]
+        self.num_units = inputs.shape.as_list()[2]
+
+        self.n_bits = tf.log(tf.cast(self.length - 1, tf.float32)) / tf.log(2.0)
+        self.n_bits = tf.floor(self.n_bits) + 1
+
+        initializer = tf.constant_initializer(0.5)
+        residual_scale = tf.get_variable(self.prefix + "/residual_scale", [self.num_units], initializer=initializer)
+
+        shuffled_input = self.shuffle_inputs(inputs)
+        mem_all = inputs + residual_inputs * residual_scale
+
+        # calculate the new value
+        candidate = self.gated_linear_map(mem_all, "c", 0.5, self.num_units, self.num_units)
+        gate = tf.nn.sigmoid(self.linear_map(mem_all, "g", 0.5, self.num_units, self.num_units))
+
+        candidate = gate * shuffled_input + (1 - gate) * candidate
+
+        if self.dropout > 0:
+            candidate = tf.nn.dropout(candidate, rate=self.dropout / self.n_bits)
+        if not self.dropout == 0.0 and self.mode == tf.estimator.ModeKeys.TRAIN:
+            candidate = candidate * tf.random_normal(tf.shape(candidate), mean=1.0, stddev=0.001)
+
+        return candidate
+
+    def shuffle_inputs(self, inputs):
+        x = tf.range(0, self.length)
+        xor_indices = tf.bitwise.bitwise_xor(x, 1)
+        input_xor = tf.gather(inputs[:, :, :self.num_units // 2], xor_indices, axis=1)
+        return tf.concat([input_xor, inputs[:, :, self.num_units // 2:]], axis=2)
+
+
+def shuffle_network(inputs, hparams):
+    """Neural Benes Network with skip connections between blocks."""
+
+    def forward_step(state, layer_nr):
+        with tf.variable_scope("forward"):
+            last_state, residuals = state
+            prev = residuals[layer_nr, :, :, :]
+            cur = SwitchLayer("switch", hparams.dropout, hparams.mode)(last_state, prev)
+            return shuffle_layer(cur), residuals
+
+    def reverse_step(state, layer_nr):
+        with tf.variable_scope("reverse"):
+            last_state, residuals = state
+            prev = residuals[layer_nr, :, :, :]
+            cur = SwitchLayer("reverse_switch", hparams.dropout, hparams.mode)(last_state, prev)
+            return reverse_shuffle_layer(cur), residuals
+
+    input_shape = tf.shape(inputs)
+    n_bits = tf.log(tf.cast(input_shape[1] - 1, tf.float32)) / tf.log(2.0)
+    n_bits = tf.cast(n_bits, tf.int32) + 1
+
+    residuals_queue = tf.zeros([n_bits * 2, input_shape[0], input_shape[1], input_shape[2]])
+    block_out = tf.tanh(inputs)
+
+    for k in range(hparams.num_hidden_layers):
+        with tf.variable_scope("benes_block_" + str(k), reuse=tf.AUTO_REUSE):
+            forward_outputs, _ = tf.scan(
+                forward_step,
+                tf.range(0, n_bits),
+                initializer=(block_out, residuals_queue),
+                parallel_iterations=1,
+                swap_memory=True
+            )
+
+            forward_outputs = tf.concat([tf.expand_dims(block_out, axis=0), forward_outputs], axis=0)
+            forward_last = forward_outputs[-1, :, :, :]
+
+            reverse_outputs, _ = tf.scan(
+                reverse_step,
+                tf.range(n_bits, n_bits * 2),
+                initializer=(forward_last, residuals_queue),
+                parallel_iterations=1,
+                swap_memory=True
+            )
+
+            block_out = reverse_outputs[-1, :, :, :]
+            residuals_queue = tf.concat([forward_outputs, reverse_outputs], axis=0)
+
+    return SwitchLayer("last_layer", hparams.dropout, hparams.mode)(block_out, residuals_queue[n_bits * 2, :, :, :])
+
+
+@registry.register_model
+class ShuffleNetwork(t2t_model.T2TModel):
+    """
+    Implementation of "Neural Shuffle-Exchange Networks − Sequence Processing in O(n log n) Time" paper
+    by K.Freivalds, E.Ozolins, A.Sostaks.
+    Paper: https://papers.nips.cc/paper/8889-neural-shuffle-exchange-networks-sequence-processing-in-on-log-n-time.pdf
+    """
+
+    def bottom(self, features):
+        inputs = features["inputs"]
+        targets = features["targets"]
+        inputs_length = tf.shape(inputs)[1]
+        targets_length = tf.shape(targets)[1]
+
+        length = tf.maximum(inputs_length, targets_length)
+        p = tf.log(tf.cast(length, tf.float32)) / tf.log(2.0)
+        p = tf.cast(tf.ceil(p), tf.int32)
+        pad_len = tf.pow(2, p)
+
+        features["inputs"] = tf.pad(inputs, [[0, 0], [0, pad_len - inputs_length], [0, 0], [0, 0]])
+        features["targets"] = tf.pad(targets, [[0, 0], [0, pad_len - targets_length], [0, 0], [0, 0]])
+        return super().bottom(features)
+
+    def loss(self, logits, features):
+        onehot_labels = tf.one_hot(features["targets"], self._problem_hparams.vocab_size["targets"])
+        cost_vector = tf.nn.softmax_cross_entropy_with_logits_v2(logits=logits, labels=onehot_labels)
+        return tf.reduce_mean(cost_vector)
+
+    def body(self, features):
+        inputs = tf.squeeze(features["inputs"], axis=2)
+        logits = shuffle_network(inputs, self._hparams)
+        return tf.expand_dims(logits, axis=2)
+
+
+@registry.register_hparams
+def shuffle_network_baseline():
+    """Set of hyperparameters."""
+    hparams = common_hparams.basic_params1()
+    hparams.hidden_size = 48 * 4  # feature maps
+    hparams.num_hidden_layers = 1  # block count
+
+    hparams.clip_grad_norm = 0.  # no gradient clipping
+
+    hparams.optimizer = "adam"
+    hparams.optimizer_adam_epsilon = 1e-5
+    hparams.learning_rate_schedule = "legacy"
+    hparams.learning_rate_decay_scheme = "noam"
+    hparams.learning_rate = 0.1
+    hparams.initializer_gain = 1.0
+    hparams.initializer = "uniform_unit_scaling"
+    hparams.optimizer_adam_beta1 = 0.9
+    hparams.optimizer_adam_beta2 = 0.999
+
+    hparams.dropout = 0.1
+    hparams.label_smoothing = 0.
+    hparams.weight_decay = 0.
+
+    return hparams


### PR DESCRIPTION
Added Neural Shuffle-Exchange model for Seq2Seq problems as described in [paper](https://papers.nips.cc/paper/8889-neural-shuffle-exchange-networks-sequence-processing-in-on-log-n-time) and [original code](https://github.com/LUMII-Syslab/shuffle-exchange).