### PR TITLE
Add support for training on V100 GPUs on Cloud ML

### DIFF
--- a/tensor2tensor/utils/cloud_mlengine.py
+++ b/tensor2tensor/utils/cloud_mlengine.py
@@ -35,7 +35,7 @@ import tensorflow as tf
 FLAGS = tf.flags.FLAGS
 
 CONSOLE_URL = "https://console.cloud.google.com/mlengine/jobs/"
-RUNTIME_VERSION = "1.13"
+RUNTIME_VERSION = "1.14"
 LIST_VM = "gcloud compute instances list"
 DEFAULT_PROJECT = "gcloud config get-value project"
 DEFAULT_REGION = "gcloud config get-value compute/region"
@@ -310,12 +310,15 @@ def validate_flags():
     if FLAGS.worker_gpu:
       if FLAGS.worker_gpu == 1:
         assert FLAGS.cloud_mlengine_master_type in ["standard_gpu",
-                                                    "standard_p100"]
+                                                    "standard_p100",
+                                                    "standard_v100"]
       elif FLAGS.worker_gpu == 4:
         assert FLAGS.cloud_mlengine_master_type in ["complex_model_m_gpu",
-                                                    "complex_model_m_p100"]
+                                                    "complex_model_m_p100",
+                                                    "complex_model_m_v100"]
       else:
-        assert FLAGS.cloud_mlengine_master_type == "complex_model_l_gpu"
+        assert FLAGS.cloud_mlengine_master_type in ["complex_model_l_gpu",
+                                                    "complex_model_l_v100"]
     else:
       assert FLAGS.cloud_mlengine_master_type in ["standard", "large_model",
                                                   "complex_model_s",


### PR DESCRIPTION
Updated the runtime version to 1.14 and added support for
using V100 GPUs on Cloud ML.

Test plan:
I ran several jobs with a custom problem definition on Cloud ML using each machine type (P100 and V100, medium and large) to make sure they worked.