### PR TITLE
update multistep_optimizer for tensorflow gpu

### DIFF
--- a/tensor2tensor/utils/multistep_optimizer.py
+++ b/tensor2tensor/utils/multistep_optimizer.py
@@ -27,28 +27,59 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
+from tensorflow.python.eager import context
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import resource_variable_ops
+from tensorflow.python.ops import state_ops
+from tensorflow.python.training import optimizer
+from tensorflow.python.training import training_ops
+from tensorflow.python.util.tf_export import tf_export
 
 
-class MultistepAdamOptimizer(tf.compat.v1.train.AdamOptimizer):
+
+class MultistepAdamOptimizer(optimizer.Optimizer):
   """Adam with SGD updates every n steps with accumulated gradients."""
 
   def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999, epsilon=1e-8,
                use_locking=False, name="Adam", n=1):
-    super(MultistepAdamOptimizer, self).__init__(
-        learning_rate=learning_rate, beta1=beta1, beta2=beta2, epsilon=epsilon,
-        use_locking=use_locking, name=name)
+    super(MultistepAdamOptimizer, self).__init__(use_locking=use_locking, name=name)
+    self._lr = learning_rate
+    self._beta1 = beta1
+    self._beta2 = beta2
+    self._epsilon = epsilon
+    # Tensor versions of the constructor arguments, created in _prepare().
+    self._lr_t = None
+    self._beta1_t = None
+    self._beta2_t = None
+    self._epsilon_t = None
     self._n = n  # Call Adam optimizer every n batches with accumulated grads
     self._n_t = None  # n as tensor
 
+  def _get_beta_accumulators(self):
+    with ops.init_scope():
+      if context.executing_eagerly():
+        graph = None
+      else:
+        graph = ops.get_default_graph()
+      return (self._get_non_slot_variable("beta1_power", graph=graph),
+              self._get_non_slot_variable("beta2_power", graph=graph))
+
   def _create_slots(self, var_list):
     """Create slot variables for Adam with accumulated gradients."""
-    super(MultistepAdamOptimizer, self)._create_slots(var_list)
     first_var = min(var_list, key=lambda x: x.name)
-    self._create_non_slot_variable(initial_value=0 if self._n == 1 else 1,
-                                   name="iter",
-                                   colocate_with=first_var)
+    self._create_non_slot_variable(initial_value=self._beta1, name="beta1_power", colocate_with=first_var)
+    self._create_non_slot_variable(initial_value=self._beta2, name="beta2_power", colocate_with=first_var)
+    #if iter is initialized as an int32, this optimizer could not run 
+    #with tensorflow_hub with a tensorflow-gpu version
+    self._create_non_slot_variable(initial_value=0.0 if self._n == 1 else 1.0, name="iter", colocate_with=first_var)
+    # Create slots for the first and second moments, as well as grad_acc.
     for v in var_list:
+      self._zeros_slot(v, "m", self._name)
+      self._zeros_slot(v, "v", self._name)
       self._zeros_slot(v, "grad_acc", self._name)
+
 
   def _get_iter_variable(self):
     graph = (
@@ -56,7 +87,14 @@ class MultistepAdamOptimizer(tf.compat.v1.train.AdamOptimizer):
     return self._get_non_slot_variable("iter", graph=graph)
 
   def _prepare(self):
-    super(MultistepAdamOptimizer, self)._prepare()
+    lr = self._call_if_callable(self._lr)
+    beta1 = self._call_if_callable(self._beta1)
+    beta2 = self._call_if_callable(self._beta2)
+    epsilon = self._call_if_callable(self._epsilon)
+    self._beta1_t = ops.convert_to_tensor(beta1, name="beta1")
+    self._beta2_t = ops.convert_to_tensor(beta2, name="beta2")
+    self._lr_t = ops.convert_to_tensor(lr, name="learning_rate")
+    self._epsilon_t = ops.convert_to_tensor(epsilon, name="epsilon")
     self._n_t = tf.convert_to_tensor(self._n, name="n")
 
   def _apply_cond(self, apply_fn, grad, var, *args, **kwargs):
@@ -81,24 +119,64 @@ class MultistepAdamOptimizer(tf.compat.v1.train.AdamOptimizer):
         lambda: accumulate_gradient(grad_acc, grad))
 
   def _apply_dense(self, grad, var):
-    return self._apply_cond(
-        super(MultistepAdamOptimizer, self)._apply_dense, grad, var)
+    m = self.get_slot(var, "m")
+    v = self.get_slot(var, "v")
+    beta1_power, beta2_power = self._get_beta_accumulators()
+    return training_ops.apply_adam(var, m, v, 
+        math_ops.cast(beta1_power, var.dtype.base_dtype), 
+        math_ops.cast(beta2_power, var.dtype.base_dtype), 
+        math_ops.cast(self._lr_t, var.dtype.base_dtype), 
+        math_ops.cast(self._beta1_t, var.dtype.base_dtype), 
+        math_ops.cast(self._beta2_t, var.dtype.base_dtype), 
+        math_ops.cast(self._epsilon_t, var.dtype.base_dtype), 
+        grad, 
+        use_locking=self._use_locking).op
 
   def _resource_apply_dense(self, grad, var):
-    return self._apply_cond(
-        super(MultistepAdamOptimizer, self)._resource_apply_dense, grad, var)
+    m = self.get_slot(var, "m")
+    v = self.get_slot(var, "v")
+    beta1_power, beta2_power = self._get_beta_accumulators()
+    return training_ops.resource_apply_adam(var.handle,
+        m.handle, 
+        v.handle,
+        math_ops.cast(beta1_power, grad.dtype.base_dtype), 
+        math_ops.cast(beta2_power, grad.dtype.base_dtype), 
+        math_ops.cast(self._lr_t, var.dtype.base_dtype), 
+        math_ops.cast(self._beta1_t, grad.dtype.base_dtype), 
+        math_ops.cast(self._beta2_t, grad.dtype.base_dtype), 
+        math_ops.cast(self._epsilon_t, grad.dtype.base_dtype), 
+        grad, use_locking=self._use_locking)
 
   def _apply_sparse_shared(self, grad, var, indices, scatter_add):
-    return self._apply_cond(
-        super(MultistepAdamOptimizer, self)._apply_sparse_shared, grad, var,
-        indices, scatter_add)
+    beta1_power, beta2_power = self._get_beta_accumulators()
+    beta1_power = math_ops.cast(beta1_power, var.dtype.base_dtype)
+    beta2_power = math_ops.cast(beta2_power, var.dtype.base_dtype)
+    lr_t = math_ops.cast(self._lr_t, var.dtype.base_dtype)
+    beta1_t = math_ops.cast(self._beta1_t, var.dtype.base_dtype)
+    beta2_t = math_ops.cast(self._beta2_t, var.dtype.base_dtype)
+    epsilon_t = math_ops.cast(self._epsilon_t, var.dtype.base_dtype)
+    lr = (lr_t * math_ops.sqrt(1 - beta2_power) / (1 - beta1_power))
+    # m_t = beta1 * m + (1 - beta1) * g_t
+    m = self.get_slot(var, "m")
+    m_scaled_g_values = grad * (1 - beta1_t)
+    m_t = state_ops.assign(m, m * beta1_t, use_locking=self._use_locking)
+    with ops.control_dependencies([m_t]):
+      m_t = scatter_add(m, indices, m_scaled_g_values)
+      # v_t = beta2 * v + (1 - beta2) * (g_t * g_t)
+      v = self.get_slot(var, "v")
+      v_scaled_g_values = (grad * grad) * (1 - beta2_t)
+      v_t = state_ops.assign(v, v * beta2_t, use_locking=self._use_locking)
+      with ops.control_dependencies([v_t]):
+        v_t = scatter_add(v, indices, v_scaled_g_values)
+      v_sqrt = math_ops.sqrt(v_t)
+      var_update = state_ops.assign_sub(var, lr * m_t / (v_sqrt + epsilon_t), use_locking=self._use_locking)
+      return control_flow_ops.group(*[var_update, m_t, v_t])
 
   def _apply_sparse(self, grad, var):
     # TODO(fstahlberg): Implement a sparse version
     tf.logging.warning("MultistepAdamOptimizer does not support sparse updates")
     dense_grad = tf.convert_to_tensor(grad)
-    return self._apply_cond(
-        super(MultistepAdamOptimizer, self)._apply_dense, dense_grad, var)
+    return self._apply_cond(self._apply_dense, dense_grad, var)
 
   def _resource_apply_sparse_duplicate_indices(self, grad, var, indices):
     tf.logging.warning("MultistepAdamOptimizer does not support sparse updates")
@@ -106,12 +184,17 @@ class MultistepAdamOptimizer(tf.compat.v1.train.AdamOptimizer):
     # correctly (summing them). A real sparse implementation will probably want
     # to override _resource_apply_sparse instead so it gets them de-duplicated
     # automatically.
-    dense_grad = tf.convert_to_tensor(
-        tf.IndexedSlices(values=grad, indices=indices,
-                         dense_shape=tf.shape(var)))
-    return self._apply_cond(
-        super(MultistepAdamOptimizer, self)._resource_apply_dense,
-        dense_grad, var)
+    dense_grad = tf.convert_to_tensor(tf.IndexedSlices(values=grad, 
+        indices=indices, dense_shape=tf.shape(var)))
+    return self._apply_cond(self._resource_apply_dense, dense_grad, var)
+
+  def _resource_scatter_add(self, x, i, v):
+    with ops.control_dependencies(
+        [resource_variable_ops.resource_scatter_add(x.handle, i, v)]):
+      return x.value()
+
+  def _resource_apply_sparse(self, grad, var, indices):
+    return self._apply_sparse_shared(grad, var, indices, self._resource_scatter_add)
 
   def _finish(self, update_ops, name_scope):
     """Updates beta_power variables every n batches and incrs counter."""
@@ -119,7 +202,6 @@ class MultistepAdamOptimizer(tf.compat.v1.train.AdamOptimizer):
     beta1_power, beta2_power = self._get_beta_accumulators()
     with tf.control_dependencies(update_ops):
       with tf.colocate_with(iter_):
-
         def update_beta_op():
           update_beta1 = beta1_power.assign(
               beta1_power * self._beta1_t,
@@ -131,7 +213,10 @@ class MultistepAdamOptimizer(tf.compat.v1.train.AdamOptimizer):
         maybe_update_beta = tf.cond(
             tf.equal(iter_, 0), update_beta_op, tf.no_op)
         with tf.control_dependencies([maybe_update_beta]):
-          update_iter = iter_.assign(tf.mod(iter_ + 1, self._n_t),
+          #TODO(Cuong): It is suboptimal here because we have to cast twice (float to int, 
+          #and then int to float)
+          update_iter = iter_.assign(K.cast(tf.mod(K.cast(iter_ + 1.0, dtype=dtypes.int32), self._n_t), dtype=dtypes.float32),
                                      use_locking=self._use_locking)
     return tf.group(
         *update_ops + [update_iter, maybe_update_beta], name=name_scope)
+


### PR DESCRIPTION
I found by using the original class MultistepAdamOptimizer, I got a problem of invalidArgumentError: Cannot assign a device for operation (see details below). This problem is only for tensorflow-gpu. On tensorflow it works fine. I did a lot of investigation on this (e.g. try adding normal  soft placement tf.Session(config=tf.ConfigProto(allow_soft_placement=True, log_device_placement=True)) - the trick people recommended without successful).

After investigation I found two actions needed to fix this issue. 1. Convert int to float, and 2. The class inherits directly from optimizer.Optimizer, not AdamOptimizer. With this I found it solved the issue. Note that without any of these two it will does not work.

Let me know if you have any question regarding to this pull request. Meanwhile let me know if you need the code to replicate the issue of invalidArgumentError. I tagged @fstahlberg as well as he wrote the original MultistepAdamOptimizer class.



A copy of the error.
```

Traceback (most recent call last):
  File "/home/cuong.hoang/anaconda2/envs/py36_env_tensor_gpu_pip_local/lib/python3.6/site-packages/tensorflow_core/python/client/session.py", line 1365, in _do_call
    return fn(*args)
  File "/home/cuong.hoang/anaconda2/envs/py36_env_tensor_gpu_pip_local/lib/python3.6/site-packages/tensorflow_core/python/client/session.py", line 1348, in _run_fn
    self._extend_graph()
  File "/home/cuong.hoang/anaconda2/envs/py36_env_tensor_gpu_pip_local/lib/python3.6/site-packages/tensorflow_core/python/client/session.py", line 1388, in _extend_graph
    tf_session.ExtendSession(self._session)
tensorflow.python.framework.errors_impl.InvalidArgumentError: Cannot assign a device for operation training/beta1_power/IsInitialized/VarIsInitializedOp: Could not satisfy explicit device specification '' because the node {{colocation_node training/beta1_power/IsInitialized/VarIsInitializedOp}} was colocated with a group of nodes that required incompatible device '/job:localhost/replica:0/task:0/device:GPU:0'. All available devices [/job:localhost/replica:0/task:0/device:CPU:0, /job:localhost/replica:0/task:0/device:XLA_CPU:0, /job:localhost/replica:0/task:0/device:XLA_GPU:0, /job:localhost/replica:0/task:0/device:GPU:0]. 
```