### PR TITLE
Resolving subdependencies conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'gunicorn',
         'gym',
         'h5py',
-        'kfac',
+        'kfac==0.1.5',
         'mesh-tensorflow',
         'numpy',
         'oauth2client',


### PR DESCRIPTION
kfac > 0.2 requires tensorflow-probability==0.8.0. However, T2T requires tf-probability==0.7.0.
Restricting kfac to ==0.1.5 so that it can work.