### PR TITLE
Enable depth_k != depth_v in local_attention_2d and masked_local_attention_2d

### DIFF
--- a/tensor2tensor/layers/common_attention.py
+++ b/tensor2tensor/layers/common_attention.py
@@ -3608,8 +3608,7 @@ def local_attention_2d(q,
   Args:
     q: a Tensor with shape [batch, heads, h, w, depth_k]
     k: a Tensor with shape [batch, heads, h, w, depth_k]
-    v: a Tensor with shape [batch, heads, h, w, depth_v]. In the current
-      implementation, depth_v must be equal to depth_k.
+    v: a Tensor with shape [batch, heads, h, w, depth_v]
     query_shape: an tuple indicating the height and width of each query block.
     memory_flange: an integer indicating how much to look in height and width
       from each query block.
@@ -3652,9 +3651,12 @@ def local_attention_2d(q,
         dropout_rate=0.,
         name="local_2d",
         make_image_summary=False)
-    # Put representations back into original shapes.
+
+    # Form padded output shape: [batch, heads, h_padded, w_padded, depth_v].
     padded_q_shape = common_layers.shape_list(q)
-    output = scatter_blocks_2d(output, q_indices, padded_q_shape)
+    output_shape = padded_q_shape[:4] + v_shape[4:]
+    # Put representations back into original shapes.
+    output = scatter_blocks_2d(output, q_indices, output_shape)
 
     # Remove the padding if introduced.
     output = tf.slice(output, [0, 0, 0, 0, 0],
@@ -3935,8 +3937,7 @@ def masked_local_attention_2d(q,
   Args:
     q: a Tensor with shape [batch, heads, h, w, depth_k]
     k: a Tensor with shape [batch, heads, h, w, depth_k]
-    v: a Tensor with shape [batch, heads, h, w, depth_v]. In the current
-      implementation, depth_v must be equal to depth_k.
+    v: a Tensor with shape [batch, heads, h, w, depth_v]
     query_shape: an tuple indicating the height and width of each query block.
       query_shape = block_shape
     memory_flange: an integer indicating how much to look in height and width
@@ -4000,9 +4001,12 @@ def masked_local_attention_2d(q,
         dropout_rate=0.,
         name="masked_local_2d",
         make_image_summary=False)
-    # Put representations back into original shapes.
+
+    # Form padded output shape: [batch, heads, h_padded, w_padded, depth_v].
     padded_q_shape = common_layers.shape_list(q)
-    output = scatter_blocks_2d(output, q_indices, padded_q_shape)
+    padded_output_shape = padded_q_shape[:4] + v_shape[4:]
+    # Put representations back into original shapes.
+    output = scatter_blocks_2d(output, q_indices, padded_output_shape)
 
     # Remove the padding if introduced.
     output = tf.slice(output, [0, 0, 0, 0, 0],

--- a/tensor2tensor/layers/common_attention_test.py
+++ b/tensor2tensor/layers/common_attention_test.py
@@ -517,8 +517,7 @@ class CommonAttentionTest(parameterized.TestCase, tf.test.TestCase):
       ("", 1, 1, 8, 4, 4, (2, 2)),
       ("dynamic_batch", None, 1, 8, 4, 4, (2, 2)),
       ("batches", 3, 2, 8, 4, 4, (2, 2)),
-      # TODO(trandustin): Extend function to enable depth_k != depth_v.
-      # ("depth_v", 1, 1, 8, 4, 1, (2, 2)),
+      ("depth_v", 1, 1, 8, 4, 1, (2, 2)),
       ("query_shape", 1, 1, 8, 4, 4, (4, 4)),
   )
   def testMaskedLocalAttention2D(self, batch, heads, length, depth_k, depth_v,
@@ -567,8 +566,7 @@ class CommonAttentionTest(parameterized.TestCase, tf.test.TestCase):
       ("matching_block_length", 3, 4, 25, 16, 16, (4, 4)),
       ("unmatching_block_length", 3, 4, 25, 16, 16, (5, 5)),
       ("dynamic_batch", None, 4, 25, 16, 16, (4, 4)),
-      # TODO(trandustin): Extend function to enable depth_k != depth_v.
-      # ("different_depth_v", 3, 4, 25, 16, 17, (4, 4)),
+      ("different_depth_v", 3, 4, 25, 16, 17, (4, 4)),
   )
   def testLocalUnmaskedAttention2D(self, batch, heads, length,
                                    depth_k, depth_v, query_shape):


### PR DESCRIPTION
This PR resolves a [TODO in tensor2tensor/layers/common_attention_test.py](https://github.com/tensorflow/tensor2tensor/blob/0b3ee79c460ac5b0d5bb32b9e48001a933cdc5db/tensor2tensor/layers/common_attention_test.py#L520) :  enable `depth_v != depth_k` for `common_attention.local_attention_2d` and `common_attention.masked_local_attention_2d`

Modification is simple: one just needs to alter the shape passed to `scatter_blocks_2d` when generating the output, so that its last dimension is taken from `v`, and not `q`

Tests:
- `pytest tensor2tensor/layers/common_attention_test.py tensor2tensor/layers/common_image_attention_test.py` passes
- Sanity check: if `v` is split along the depth dimension, then applying `local_attention_2d` on each of the two parts separately and concatenating the results should be equivalent to applying `local_attention_2d` with original `v` - see the code below

<details>

<summary>Expand sanity check code and output</summary>

```
import numpy as np

import pandas as pd
import tensorflow as tf

from tensor2tensor.layers.common_attention import local_attention_2d

# Check that attention is commutative with splitting/concatenating v along the depth dimension
# Try varios split points
for split_idx in range(1, 30):

    batch, heads, length, depth_k, depth_v, query_shape = 3, 4, 25, 16, 30, (4, 4)

    q = tf.random_normal([batch, heads, length, length, depth_k], dtype=tf.float64)
    k = tf.random_normal([batch, heads, length, length, depth_k], dtype=tf.float64)
    v = tf.random_normal([batch, heads, length, length, depth_v], dtype=tf.float64)
    
    # Apply attention with the first part of v
    output_part1 = local_attention_2d(
        q,
        k,
        v[:, :, :, :, :split_idx],
        query_shape=query_shape,
        memory_flange=(3, 3))
    
    # Apply attention with the second part of v
    output_part2 = local_attention_2d(
        q,
        k,
        v[:, :, :, :, split_idx:],
        query_shape=query_shape,
        memory_flange=(3, 3))
    
    # Put together results of two parts
    output_concat = tf.concat([output_part1, output_part2], axis=4)
    
    # Apply attention with the original v
    output_full = local_attention_2d(
        q,
        k,
        v,
        query_shape=query_shape,
        memory_flange=(3, 3))
    
    # Compute the difference - should be small
    with tf.Session() as sess:
        res_diff = (output_concat - output_full).eval()
        print(np.abs(res_diff).max())


2.220446049250313e-15
2.6645352591003757e-15
2.220446049250313e-15
1.7763568394002505e-15
2.220446049250313e-15
2.220446049250313e-15
2.220446049250313e-15
0.0
2.6645352591003757e-15
1.7763568394002505e-15
2.220446049250313e-15
2.220446049250313e-15
2.6645352591003757e-15
2.220446049250313e-15
2.220446049250313e-15
0.0
2.6645352591003757e-15
2.220446049250313e-15
2.4424906541753444e-15
2.6645352591003757e-15
3.1086244689504383e-15
2.220446049250313e-15
2.220446049250313e-15
0.0
1.3322676295501878e-15
0.0
2.220446049250313e-15
0.0
1.7763568394002505e-15
```

</details>