### PR TITLE
Change kwargs=None optional parameter to **kwargs

### DIFF
--- a/tensor2tensor/rl/gym_utils.py
+++ b/tensor2tensor/rl/gym_utils.py
@@ -343,7 +343,7 @@ def make_gym_env(name,
                          output_dtype, num_actions)
 
 
-def register_gym_env(class_entry_point, version="v0", kwargs=None):
+def register_gym_env(class_entry_point, version="v0", **kwargs):
   """Registers the class in Gym and returns the registered name and the env."""
 
   split_on_colon = class_entry_point.split(":")


### PR DESCRIPTION
When running the t2t_decoder.py script from magenta, this line of code will result in this traceback:

```
Traceback (most recent call last):
  File "C:\Users\togde\Anaconda3\envs\magenta\Scripts\t2t_decoder-script.py", line 33, in <module>
    sys.exit(load_entry_point('magenta', 'console_scripts', 't2t_decoder')())
  File "C:\Users\togde\Anaconda3\envs\magenta\Scripts\t2t_decoder-script.py", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "C:\Users\togde\Anaconda3\envs\magenta\lib\site-packages\importlib_metadata\__init__.py", line 194, in load
    module = import_module(match.group('module'))
  File "C:\Users\togde\Anaconda3\envs\magenta\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "c:\users\togde\programmingprojects\magenta\magenta\tensor2tensor\t2t_decoder.py", line 19, in <module>
    from magenta.tensor2tensor import models  # pylint: disable=unused-import
  File "c:\users\togde\programmingprojects\magenta\magenta\tensor2tensor\models.py", line 18, in <module>
    from magenta.models.score2perf import score2perf_hparams
  File "c:\users\togde\programmingprojects\magenta\magenta\models\score2perf\__init__.py", line 17, in <module>
    from magenta.models.score2perf import score2perf
  File "c:\users\togde\programmingprojects\magenta\magenta\models\score2perf\score2perf.py", line 30, in <module>
    from tensor2tensor.models import transformer
  File "C:\Users\togde\Anaconda3\envs\magenta\lib\site-packages\tensor2tensor\models\__init__.py", line 51, in <module>
    from tensor2tensor.models.research import rl
  File "C:\Users\togde\Anaconda3\envs\magenta\lib\site-packages\tensor2tensor\models\research\rl.py", line 27, in <module>
    from tensor2tensor.envs import tic_tac_toe_env
  File "C:\Users\togde\Anaconda3\envs\magenta\lib\site-packages\tensor2tensor\envs\__init__.py", line 23, in <module>
    from tensor2tensor.envs import tic_tac_toe_env
  File "C:\Users\togde\Anaconda3\envs\magenta\lib\site-packages\tensor2tensor\envs\tic_tac_toe_env.py", line 244, in <module>
    register()
  File "C:\Users\togde\Anaconda3\envs\magenta\lib\site-packages\tensor2tensor\envs\tic_tac_toe_env.py", line 240, in register
    "tensor2tensor.envs.tic_tac_toe_env:TicTacToeEnv", version="v0")
  File "C:\Users\togde\Anaconda3\envs\magenta\lib\site-packages\tensor2tensor\rl\gym_utils.py", line 360, in register_gym_env
    return env_name, gym.make(env_name)
  File "C:\Users\togde\Anaconda3\envs\magenta\lib\site-packages\gym\envs\registration.py", line 676, in make
    return registry.make(id, **kwargs)
  File "C:\Users\togde\Anaconda3\envs\magenta\lib\site-packages\gym\envs\registration.py", line 520, in make
    return spec.make(**kwargs)
  File "C:\Users\togde\Anaconda3\envs\magenta\lib\site-packages\gym\envs\registration.py", line 133, in make
    _kwargs = self.kwargs.copy()
AttributeError: 'NoneType' object has no attribute 'copy'
```

The tensor2tensor.rl library is automatically being imported at the start of the script, which calls the register_gym_env function in gym_utils.py with the optional kwargs argument not being supplied. Thus when gym is registering the environment, ``self.kwargs.copy()`` will throw an errors since kwargs is None.

This pull request changes the optional parameter into the more pythonic **kwargs argument that will be an empty dictionary if not supplied. This has been tested and does indeed fix the issue with magenta.